### PR TITLE
fix: reset vm state after call find_one()

### DIFF
--- a/src/polodb_core/db.rs
+++ b/src/polodb_core/db.rs
@@ -430,6 +430,65 @@ mod tests {
     }
 
     #[test]
+    fn test_multiple_find_one() {
+        let mut db = prepare_db("test-multiple-find-one").unwrap();
+        {
+            let mut collection = db.collection("config").unwrap();
+            let mut doc1 = mk_document! {
+                "_id": "c1",
+                "value": "c1",
+            };
+            collection.insert(&mut doc1).unwrap();
+
+            let mut doc2 = mk_document! {
+                "_id": "c2",
+                "value": "c2",
+            };
+            collection.insert(&mut doc2).unwrap();
+
+            let mut doc2 = mk_document! {
+                "_id": "c3",
+                "value": "c3",
+            };
+            collection.insert(&mut doc2).unwrap();
+
+            assert_eq!(collection.count().unwrap(), 3);
+        }
+
+        {
+            let mut collection = db.collection("config").unwrap();
+            collection.update(Some(&mk_document! {
+                "_id": "c2",
+            }), &mk_document! {
+                "$set": mk_document! {
+                    "value": "c33",
+                },
+            }).unwrap();
+            collection.update(Some(&mk_document! {
+                "_id": "c2",
+            }), &mk_document! {
+                "$set": mk_document! {
+                    "value": "c22",
+                },
+            }).unwrap();
+        }
+
+        let mut collection = db.collection("config").unwrap();
+        let doc1 = collection.find_one(&mk_document! {
+            "_id": "c1",
+        }).unwrap().unwrap();
+
+        assert_eq!(doc1.get("value").unwrap().unwrap_string(), "c1");
+
+        let mut collection = db.collection("config").unwrap();
+        let doc1 = collection.find_one(&mk_document! {
+            "_id": "c2",
+        }).unwrap().unwrap();
+
+        assert_eq!(doc1.get("value").unwrap().unwrap_string(), "c22");
+    }
+
+    #[test]
     fn test_rollback() {
         let mut db = prepare_db("test-rollback").unwrap();
         let mut collection = db.create_collection("test").unwrap();


### PR DESCRIPTION
Fix #45 
- the transaction state is wrong after call the function `find_one()`
- the vm should be manually closed after find()