### PR TITLE
Feat: add regex "$query" filter

### DIFF
--- a/src/polodb_core/Cargo.toml
+++ b/src/polodb_core/Cargo.toml
@@ -32,6 +32,7 @@ serde-wasm-bindgen = "0.5.0"
 wasm-bindgen-futures = "0.4.34"
 thiserror = "1.0.40"
 indexmap = { version = "1.9.3", features = ["serde"] }
+regex = "1"
 
 [dependencies.web-sys]
 version = "0.3.61"

--- a/src/polodb_core/Cargo.toml
+++ b/src/polodb_core/Cargo.toml
@@ -9,8 +9,8 @@ description = "An embedded document database"
 keywords = ["database", "embedded", "cross-platform"]
 
 [lib]
-name="polodb_core"
-path="lib.rs"
+name = "polodb_core"
+path = "lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -22,7 +22,14 @@ getrandom = { version = "0.2.3", features = ["js"] }
 byteorder = "1.4.3"
 num_enum = "0.6.0"
 serde = { version = "1.0.125", features = ["rc"] }
-uuid = { version = "1.3.0", features = ["atomic", "v1", "v4", "wasm-bindgen", "js", "getrandom"] }
+uuid = { version = "1.3.0", features = [
+    "atomic",
+    "v1",
+    "v4",
+    "wasm-bindgen",
+    "js",
+    "getrandom",
+] }
 smallvec = { version = "1.10.0", features = ["union", "write", "const_new"] }
 memmap2 = "0.5.10"
 wasm-bindgen = "0.2.84"
@@ -32,14 +39,11 @@ serde-wasm-bindgen = "0.5.0"
 wasm-bindgen-futures = "0.4.34"
 thiserror = "1.0.40"
 indexmap = { version = "1.9.3", features = ["serde"] }
-regex = "1"
+regex = "1.8"
 
 [dependencies.web-sys]
 version = "0.3.61"
-features = [
-    'Window',
-    'console',
-]
+features = ['Window', 'console']
 
 [dev-dependencies]
 polodb_line_diff = { path = "../polodb_line_diff" }

--- a/src/polodb_core/errors.rs
+++ b/src/polodb_core/errors.rs
@@ -122,7 +122,7 @@ pub struct DuplicateKeyError {
 }
 
 #[derive(Debug)]
-pub struct RegexCompileError {
+pub struct RegexError {
     pub error: String,
     pub expression: String,
     pub options: String,
@@ -248,7 +248,7 @@ pub enum Error {
     #[error("the element type {0} is unknown")]
     UnknownBsonElementType(u8),
     #[error("failed to compile regex expression: {}, expression: {}, options: {}", .0.error, .0.expression, .0.options)]
-    RegexCompileError(Box<RegexCompileError>),
+    RegexCompileError(Box<RegexError>),
 }
 
 impl Error {
@@ -315,8 +315,8 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<RegexCompileError> for Error {
-    fn from(value: RegexCompileError) -> Self {
+impl From<RegexError> for Error {
+    fn from(value: RegexError) -> Self {
         Error::RegexCompileError(Box::new(value))
     }
 }

--- a/src/polodb_core/errors.rs
+++ b/src/polodb_core/errors.rs
@@ -247,8 +247,8 @@ pub enum Error {
     DuplicateKey(Box<DuplicateKeyError>),
     #[error("the element type {0} is unknown")]
     UnknownBsonElementType(u8),
-    #[error("failed to compile regex expression: {}, expression: {}, options: {}", .0.error, .0.expression, .0.options)]
-    RegexCompileError(Box<RegexError>),
+    #[error("failed to run regex expression: {}, expression: {}, options: {}", .0.error, .0.expression, .0.options)]
+    RegexError(Box<RegexError>),
 }
 
 impl Error {
@@ -317,7 +317,7 @@ impl From<io::Error> for Error {
 
 impl From<RegexError> for Error {
     fn from(value: RegexError) -> Self {
-        Error::RegexCompileError(Box::new(value))
+        Error::RegexError(Box::new(value))
     }
 }
 

--- a/src/polodb_core/tests/test_regex.rs
+++ b/src/polodb_core/tests/test_regex.rs
@@ -1,0 +1,92 @@
+use bson::{doc, Document, Regex};
+use polodb_core::Database;
+
+mod common;
+
+use common::prepare_db;
+
+#[test]
+fn test_regex() {
+    vec![
+        (prepare_db("test-regex").unwrap(), true),
+        (Database::open_memory().unwrap(), false),
+    ]
+    .iter()
+    .for_each(|(db, _)| {
+        let metrics = db.metrics();
+        metrics.enable();
+
+        let collection = db.collection::<Document>("config");
+        let docs = vec![
+            doc! {
+                "_id": "c1",
+                "value": "c1",
+            },
+            doc! {
+                "_id": "invalid",
+                "value": "not-valid-value",
+            },
+            doc! {
+                "_id": "c3",
+                "value": "c3"
+            },
+        ];
+        collection.insert_many(&docs).unwrap();
+
+        let res = collection
+            .find(doc! {
+                "value": {
+                    "$regex": Regex {
+                        pattern: "c[0-9]+".into(),
+                        options: "i".into(),
+                    },
+                }
+            })
+            .unwrap();
+
+        assert_eq!(res.count(), docs.len() - 1);
+    });
+}
+
+#[test]
+fn test_regex_error() {
+    vec![
+        (prepare_db("test-regex-error").unwrap(), true),
+        (Database::open_memory().unwrap(), false),
+    ]
+    .iter()
+    .for_each(|(db, _)| {
+        let metrics = db.metrics();
+        metrics.enable();
+
+        let collection = db.collection::<Document>("config");
+        let docs = vec![
+            doc! {
+                "_id": "c1",
+                "value": "c1",
+            },
+            doc! {
+                "_id": "invalid",
+                "value": "not-valid-value",
+            },
+            doc! {
+                "_id": "c3",
+                "value": "c3"
+            },
+        ];
+        collection.insert_many(&docs).unwrap();
+
+        let mut res = collection
+            .find(doc! {
+                "value": {
+                    "$regex": Regex {
+                        pattern: "c[0-9]+".into(),
+                        options: "pml".into(), // invalid option
+                    },
+                }
+            })
+            .unwrap();
+
+        assert!(res.next().unwrap().is_err());
+    });
+}

--- a/src/polodb_core/vm/op.rs
+++ b/src/polodb_core/vm/op.rs
@@ -203,6 +203,7 @@ pub enum DbOp {
     GreaterEqual,
     Less,
     LessEqual,
+    Regex,
 
     // check if top0 is in top2
     // the result is stored in r0

--- a/src/polodb_core/vm/vm.rs
+++ b/src/polodb_core/vm/vm.rs
@@ -837,7 +837,7 @@ impl VM {
 
                         if let Bson::RegularExpression(re) = val2 {
                             let mut re_build = RegexBuilder::new(re.pattern.as_str());
-                            for char in re.pattern.chars() {
+                            for char in re.options.chars() {
                                 match char {
                                     'i' => {
                                         re_build.case_insensitive(true);

--- a/src/polodb_core/vm/vm.rs
+++ b/src/polodb_core/vm/vm.rs
@@ -862,7 +862,7 @@ impl VM {
                                             error: format!("unknown regex option: {}", char),
                                             expression: re.pattern.clone(),
                                             options: re.options.clone(),
-                                        }))
+                                        }));
                                     }
                                 }
                             }


### PR DESCRIPTION
# Add MongoDB `$regex` query filter

## TODO
- [x] implement `$regex`
  - [x] Add `DbOp::Regex`
  - [x] Implement `$regex` match in `codegen.rs`
  - [x] Implement `$regex` match in `vm.rs`
  - [x] Implement `Error::RegexError`
  - [x] Implement `$regex` match in `subprogram.rs`
- [x] implement unit tests

closes #107 