### PR TITLE
fix: persist issue after second insert

### DIFF
--- a/src/polodb_core/lsm/lsm_backend/lsm_file_backend.rs
+++ b/src/polodb_core/lsm/lsm_backend/lsm_file_backend.rs
@@ -556,7 +556,7 @@ impl LsmFileBackendInner {
         let next_meta_pid = snapshot.next_meta_pid();
         let mut meta_page = self.read_page(meta_pid)?;
 
-        snapshot.write_to_page(&mut meta_page);
+        snapshot.write_to_page(&mut meta_page, snapshot.meta_id + 1);
 
         // update pid and write page
         meta_page.page_id = next_meta_pid as u32;

--- a/src/polodb_core/lsm/lsm_snapshot/lsm_snapshot.rs
+++ b/src/polodb_core/lsm/lsm_snapshot/lsm_snapshot.rs
@@ -82,9 +82,9 @@ impl LsmSnapshot {
         }
     }
 
-    pub fn write_to_page(&self, page: &mut RawPage) {
+    pub fn write_to_page(&self, page: &mut RawPage, meta_id: u64) {
         let mut delegate = LsmMetaDelegate(page);
-        delegate.set_meta_id(self.meta_id);
+        delegate.set_meta_id(meta_id);
         delegate.set_log_offset(self.log_offset);
         delegate.set_db_file_size(self.file_size);
 


### PR DESCRIPTION
The ID of the snapshot doesn't update properly. So the second insert of the db will be discarded.