### PR TITLE
Feat: add `$all` operator

### DIFF
--- a/src/polodb_core/Cargo.toml
+++ b/src/polodb_core/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["database", "embedded", "cross-platform"]
 [lib]
 name = "polodb_core"
 path = "lib.rs"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 libc = "0.2"

--- a/src/polodb_core/errors.rs
+++ b/src/polodb_core/errors.rs
@@ -149,6 +149,13 @@ pub struct RegexError {
     pub options: String,
 }
 
+#[derive(Debug)]
+pub struct AllError {
+    pub field_key: String,
+    pub field_value: String,
+    pub field_type: String,
+}
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("unexpected id type, expected: {0}, actual: {1}")]
@@ -278,6 +285,8 @@ pub enum Error {
     SetIsNotADocument,
     #[error("the field '{0}' is not a valid field name")]
     UpsertError(String),
+    #[error("the field {} is not an array; value: {}, type: {}", .0.field_key, .0.field_value, .0.field_type)]
+    AllError(Box<AllError>),
 }
 
 impl Error {
@@ -340,6 +349,12 @@ impl From<io::Error> for Error {
 impl From<RegexError> for Error {
     fn from(value: RegexError) -> Self {
         Error::RegexError(Box::new(value))
+    }
+}
+
+impl From<AllError> for Error {
+    fn from(value: AllError) -> Self {
+        Error::AllError(Box::new(value))
     }
 }
 

--- a/src/polodb_core/tests/test_all.rs
+++ b/src/polodb_core/tests/test_all.rs
@@ -1,0 +1,78 @@
+use bson::{doc, Document};
+use polodb_core::Database;
+
+mod common;
+
+use common::prepare_db;
+
+#[test]
+fn test_all() {
+    vec![
+        (prepare_db("test-all").unwrap(), true),
+        (Database::open_memory().unwrap(), false),
+    ]
+    .iter()
+    .for_each(|(db, _)| {
+        let metrics = db.metrics();
+        metrics.enable();
+
+        let collection = db.collection::<Document>("config");
+        let docs = vec![
+            doc! {
+                "_id": "c1",
+                "value": ["c1", "c2", "c3"],
+            },
+            doc! {
+                "_id": "invalid",
+                "value": ["c1", "c2", "c4"],
+            },
+        ];
+        collection.insert_many(&docs).unwrap();
+
+        let res = collection
+            .find(doc! {
+                "value": {
+                    "$all": ["c2", "c3"],
+                }
+            })
+            .unwrap();
+
+        assert_eq!(res.count(), docs.len() - 1);
+    });
+}
+
+#[test]
+fn test_all_error() {
+    vec![
+        (prepare_db("test-all-error").unwrap(), true),
+        (Database::open_memory().unwrap(), false),
+    ]
+    .iter()
+    .for_each(|(db, _)| {
+        let metrics = db.metrics();
+        metrics.enable();
+
+        let collection = db.collection::<Document>("config");
+        let docs = vec![
+            doc! {
+                "_id": "c1",
+                "arr": ["c1", "c2", "c3"],
+            },
+            doc! {
+                "_id": "invalid2",
+                "value": "not-valid-value",
+            },
+        ];
+        collection.insert_many(&docs).unwrap();
+
+        let mut res = collection
+            .find(doc! {
+                "value": {
+                    "$all": ["c2", "c3"],
+                }
+            })
+            .unwrap();
+
+        assert!(res.next().unwrap().is_err());
+    });
+}

--- a/src/polodb_core/tests/test_index.rs
+++ b/src/polodb_core/tests/test_index.rs
@@ -279,7 +279,7 @@ fn test_delete_with_index() {
         let count = col.count_documents().unwrap();
         assert_eq!(count, 0);
 
-        let result = col.find_one(doc! {
+        col.find_one(doc! {
             "age": 33
         }).unwrap();
         assert_eq!(result, None);

--- a/src/polodb_core/utils/bson.rs
+++ b/src/polodb_core/utils/bson.rs
@@ -16,11 +16,50 @@ use std::cmp::Ordering;
 use std::io::{BufRead, Read, Write};
 use bson::{Bson, DateTime, Decimal128, Document, Timestamp};
 use bson::oid::ObjectId;
-use bson::spec::ElementType;
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use bson::ser::Error as BsonErr;
 use bson::ser::Result as BsonResult;
+use bson::spec::ElementType as BsonElementType;
+use bson::{Bson, DateTime, Decimal128, Document, Timestamp};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use std::cmp::Ordering;
+use std::io::{BufRead, Read, Write};
 use crate::{Error, Result};
+
+pub(crate) struct ElementType(BsonElementType);
+
+impl From<BsonElementType> for ElementType {
+    fn from(element_type: BsonElementType) -> Self {
+        ElementType(element_type)
+    }
+}
+
+impl ToString for ElementType {
+    fn to_string(&self) -> String {
+        match self.0 {
+            BsonElementType::Double => String::from("Double"),
+            BsonElementType::String => String::from("String"),
+            BsonElementType::EmbeddedDocument => String::from("EmbeddedDocument"),
+            BsonElementType::Array => String::from("Array"),
+            BsonElementType::Binary => String::from("Binary"),
+            BsonElementType::Undefined => String::from("Undefined"),
+            BsonElementType::ObjectId => String::from("ObjectId"),
+            BsonElementType::Boolean => String::from("Boolean"),
+            BsonElementType::DateTime => String::from("DateTime"),
+            BsonElementType::Null => String::from("Null"),
+            BsonElementType::RegularExpression => String::from("RegularExpression"),
+            BsonElementType::DbPointer => String::from("DbPointer"),
+            BsonElementType::JavaScriptCode => String::from("JavaScriptCode"),
+            BsonElementType::Symbol => String::from("Symbol"),
+            BsonElementType::JavaScriptCodeWithScope => String::from("JavaScriptCodeWithScope"),
+            BsonElementType::Int32 => String::from("Int32"),
+            BsonElementType::Timestamp => String::from("Timestamp"),
+            BsonElementType::Int64 => String::from("Int64"),
+            BsonElementType::Decimal128 => String::from("Decimal128"),
+            BsonElementType::MaxKey => String::from("MaxKey"),
+            BsonElementType::MinKey => String::from("MinKey"),
+        }
+    }
+}
 
 pub fn stacked_key<'a, T: IntoIterator<Item = &'a Bson>>(keys: T) -> Result<Vec<u8>> {
     let mut result = Vec::<u8>::new();
@@ -35,75 +74,75 @@ pub fn stacked_key<'a, T: IntoIterator<Item = &'a Bson>>(keys: T) -> Result<Vec<
 pub fn stacked_key_bytes<W: Write>(writer: &mut W, key: &Bson) -> Result<()> {
     match key {
         Bson::Double(dbl) => {
-            writer.write_u8(ElementType::Double as u8)?;
+            writer.write_u8(BsonElementType::Double as u8)?;
             writer.write_f64::<BigEndian>(*dbl)?;
         }
         Bson::String(str) => {
-            writer.write_u8(ElementType::String as u8)?;
+            writer.write_u8(BsonElementType::String as u8)?;
 
             writer.write_all(str.as_bytes())?;
 
             writer.write_u8(0)?;
         }
         Bson::Boolean(bl) => {
-            writer.write_u8(ElementType::Boolean as u8)?;
+            writer.write_u8(BsonElementType::Boolean as u8)?;
 
             writer.write_u8(*bl as u8)?;
         }
         Bson::Null => {
-            writer.write_u8(ElementType::Null as u8)?;
+            writer.write_u8(BsonElementType::Null as u8)?;
         }
         Bson::Int32(i32) => {
-            writer.write_u8(ElementType::Int32 as u8)?;
+            writer.write_u8(BsonElementType::Int32 as u8)?;
 
             writer.write_i32::<BigEndian>(*i32)?;
         }
         Bson::Int64(i64) => {
-            writer.write_u8(ElementType::Int64 as u8)?;
+            writer.write_u8(BsonElementType::Int64 as u8)?;
 
             writer.write_i64::<BigEndian>(*i64)?;
         }
         Bson::Timestamp(ts) => {
-            writer.write_u8(ElementType::Timestamp as u8)?;
+            writer.write_u8(BsonElementType::Timestamp as u8)?;
 
             let u64 = ((ts.time as u64) << 32) | (ts.increment as u64);
 
             writer.write_u64::<BigEndian>(u64)?;
         }
         Bson::ObjectId(oid) => {
-            writer.write_u8(ElementType::ObjectId as u8)?;
+            writer.write_u8(BsonElementType::ObjectId as u8)?;
 
             let bytes = oid.bytes();
             writer.write_all(&bytes)?;
         }
         Bson::DateTime(dt) => {
-            writer.write_u8(ElementType::DateTime as u8)?;
+            writer.write_u8(BsonElementType::DateTime as u8)?;
 
             let t = dt.timestamp_millis();
 
             writer.write_i64::<BigEndian>(t)?;
         }
         Bson::Symbol(str) => {
-            writer.write_u8(ElementType::Symbol as u8)?;
+            writer.write_u8(BsonElementType::Symbol as u8)?;
 
             writer.write_all(str.as_bytes())?;
 
             writer.write_u8(0)?;
         }
         Bson::Decimal128(dcl) => {
-            writer.write_u8(ElementType::Decimal128 as u8)?;
+            writer.write_u8(BsonElementType::Decimal128 as u8)?;
 
             let bytes = dcl.bytes();
 
             writer.write_all(&bytes)?;
         }
         Bson::Undefined => {
-            writer.write_u8(ElementType::Undefined as u8)?;
+            writer.write_u8(BsonElementType::Undefined as u8)?;
         }
 
         _ => {
             let val = format!("{:?}", key);
-            return Err(Error::NotAValidKeyType(val))
+            return Err(Error::NotAValidKeyType(val));
         }
     }
 
@@ -120,51 +159,51 @@ pub fn split_stacked_keys(buffer: &[u8]) -> Result<Vec<Bson>> {
             break;
         }
         let ch = ch_result.unwrap();
-        if ch == ElementType::Double as u8 {
+        if ch == BsonElementType::Double as u8 {
             let val = reader.read_f64::<BigEndian>()?;
             result.push(Bson::Double(val));
-        } else if ch == ElementType::String as u8 {
+        } else if ch == BsonElementType::String as u8 {
             let mut bytes = Vec::<u8>::new();
             reader.read_until(0, &mut bytes)?;
             // remove last byte of bytes
             bytes.pop();
             result.push(Bson::String(String::from_utf8(bytes)?));
-        } else if ch == ElementType::Boolean as u8 {
+        } else if ch == BsonElementType::Boolean as u8 {
             let val = reader.read_u8()?;
             result.push(Bson::Boolean(if val == 0 { false } else { true }));
-        } else if ch == ElementType::Null as u8 {
+        } else if ch == BsonElementType::Null as u8 {
             result.push(Bson::Null);
-        } else if ch == ElementType::Int32 as u8 {
+        } else if ch == BsonElementType::Int32 as u8 {
             let val = reader.read_i32::<BigEndian>()?;
             result.push(Bson::Int32(val));
-        } else if ch == ElementType::Int64 as u8 {
+        } else if ch == BsonElementType::Int64 as u8 {
             let val = reader.read_i64::<BigEndian>()?;
             result.push(Bson::Int64(val));
-        } else if ch == ElementType::Timestamp as u8 {
+        } else if ch == BsonElementType::Timestamp as u8 {
             let val = reader.read_u64::<BigEndian>()?;
             let timestamp = Timestamp {
                 time: (val >> 32) as u32,
                 increment: val as u32,
             };
             result.push(Bson::Timestamp(timestamp));
-        } else if ch == ElementType::ObjectId as u8 {
+        } else if ch == BsonElementType::ObjectId as u8 {
             let mut bytes = [0u8; 12];
             reader.read_exact(&mut bytes)?;
             result.push(Bson::ObjectId(ObjectId::from_bytes(bytes)));
-        } else if ch == ElementType::DateTime as u8 {
+        } else if ch == BsonElementType::DateTime as u8 {
             let val = reader.read_i64::<BigEndian>()?;
             let datetime = DateTime::from_millis(val);
             result.push(Bson::DateTime(datetime));
-        } else if ch == ElementType::Symbol as u8 {
+        } else if ch == BsonElementType::Symbol as u8 {
             let mut bytes = Vec::<u8>::new();
             reader.read_until(0, &mut bytes)?;
             bytes.pop();
             result.push(Bson::Symbol(String::from_utf8(bytes)?));
-        } else if ch == ElementType::Decimal128 as u8 {
+        } else if ch == BsonElementType::Decimal128 as u8 {
             let mut bytes = [0u8; 16];
             reader.read_exact(&mut bytes)?;
             result.push(Bson::Decimal128(Decimal128::from_bytes(bytes)));
-        } else if ch == ElementType::Undefined as u8 {
+        } else if ch == BsonElementType::Undefined as u8 {
             result.push(Bson::Undefined);
         } else {
             return Err(Error::UnknownBsonElementType(ch));
@@ -185,20 +224,20 @@ pub fn value_cmp(a: &Bson, b: &Bson) -> BsonResult<Ordering> {
         (Bson::Int64(i1), Bson::Int32(i2)) => {
             let i2_64 = *i2 as i64;
             Ok(i1.cmp(&i2_64))
-        },
+        }
         (Bson::Int32(i1), Bson::Int64(i2)) => {
             let i1_64 = *i1 as i64;
             Ok(i1_64.cmp(i2))
-        },
+        }
         (Bson::Double(d1), Bson::Double(d2)) => Ok(d1.total_cmp(d2)),
         (Bson::Double(d1), Bson::Int32(d2)) => {
             let f = *d2 as f64;
             Ok(d1.total_cmp(&f))
-        },
+        }
         (Bson::Double(d1), Bson::Int64(d2)) => {
             let f = *d2 as f64;
             Ok(d1.total_cmp(&f))
-        },
+        }
         (Bson::Int32(i1), Bson::Double(d2)) => {
             let f = *i1 as f64;
             Ok(f.total_cmp(d2))
@@ -219,7 +258,7 @@ pub fn value_cmp(a: &Bson, b: &Bson) -> BsonResult<Ordering> {
             }
 
             Err(BsonErr::InvalidCString("Unsupported types".to_string()))
-        },
+        }
     }
 }
 
@@ -236,9 +275,7 @@ fn try_get_document_by_slices(doc: &Document, keys: &[&str]) -> Option<Bson> {
             let remains = &keys[1..];
             let value = doc.get(first_str);
             match value {
-                Some(Bson::Document(doc)) => {
-                    try_get_document_by_slices(doc, remains)
-                }
+                Some(Bson::Document(doc)) => try_get_document_by_slices(doc, remains),
                 Some(v) => {
                     if remains.is_empty() {
                         return Some(v.clone());
@@ -252,35 +289,68 @@ fn try_get_document_by_slices(doc: &Document, keys: &[&str]) -> Option<Bson> {
 }
 
 pub fn bson_datetime_now() -> bson::datetime::DateTime {
-    return bson::datetime::DateTime::now()
+    return bson::datetime::DateTime::now();
 }
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::Ordering;
-    use bson::{Bson, doc, Timestamp};
-    use bson::oid::ObjectId;
     use crate::utils::bson::{split_stacked_keys, stacked_key, value_cmp};
+    use bson::oid::ObjectId;
+    use bson::{doc, Bson, Timestamp};
+    use std::cmp::Ordering;
 
     #[test]
     fn test_value_cmp() {
-        assert_eq!(value_cmp(&Bson::Int32(2), &Bson::Int64(3)).unwrap(), Ordering::Less);
-        assert_eq!(value_cmp(&Bson::Int32(2), &Bson::Int64(1)).unwrap(), Ordering::Greater);
-        assert_eq!(value_cmp(&Bson::Int32(1), &Bson::Int64(1)).unwrap(), Ordering::Equal);
-        assert_eq!(value_cmp(&Bson::Int64(2), &Bson::Int32(3)).unwrap(), Ordering::Less);
-        assert_eq!(value_cmp(&Bson::Int64(2), &Bson::Int32(1)).unwrap(), Ordering::Greater);
-        assert_eq!(value_cmp(&Bson::Int64(1), &Bson::Int32(1)).unwrap(), Ordering::Equal);
+        assert_eq!(
+            value_cmp(&Bson::Int32(2), &Bson::Int64(3)).unwrap(),
+            Ordering::Less
+        );
+        assert_eq!(
+            value_cmp(&Bson::Int32(2), &Bson::Int64(1)).unwrap(),
+            Ordering::Greater
+        );
+        assert_eq!(
+            value_cmp(&Bson::Int32(1), &Bson::Int64(1)).unwrap(),
+            Ordering::Equal
+        );
+        assert_eq!(
+            value_cmp(&Bson::Int64(2), &Bson::Int32(3)).unwrap(),
+            Ordering::Less
+        );
+        assert_eq!(
+            value_cmp(&Bson::Int64(2), &Bson::Int32(1)).unwrap(),
+            Ordering::Greater
+        );
+        assert_eq!(
+            value_cmp(&Bson::Int64(1), &Bson::Int32(1)).unwrap(),
+            Ordering::Equal
+        );
     }
 
     #[test]
     fn test_try_get_document_value() {
-        assert_eq!(super::try_get_document_value(&doc!{}, "a"), None);
-        assert_eq!(super::try_get_document_value(&doc!{"a": 1}, "a"), Some(Bson::Int32(1)));
-        assert_eq!(super::try_get_document_value(&doc!{"a": 1}, "b"), None);
-        assert_eq!(super::try_get_document_value(&doc!{"a": { "b": 1 }}, "a.b"), Some(Bson::Int32(1)));
-        assert_eq!(super::try_get_document_value(&doc!{"a": { "b": 1 }}, "a.c"), None);
-        assert_eq!(super::try_get_document_value(&doc!{"a": { "b": { "c": 1 }}}, "a.b.c"), Some(Bson::Int32(1)));
-        assert_eq!(super::try_get_document_value(&doc!{"a": { "b": { "c": 1 }}}, "a.b.d"), None);
+        assert_eq!(super::try_get_document_value(&doc! {}, "a"), None);
+        assert_eq!(
+            super::try_get_document_value(&doc! {"a": 1}, "a"),
+            Some(Bson::Int32(1))
+        );
+        assert_eq!(super::try_get_document_value(&doc! {"a": 1}, "b"), None);
+        assert_eq!(
+            super::try_get_document_value(&doc! {"a": { "b": 1 }}, "a.b"),
+            Some(Bson::Int32(1))
+        );
+        assert_eq!(
+            super::try_get_document_value(&doc! {"a": { "b": 1 }}, "a.c"),
+            None
+        );
+        assert_eq!(
+            super::try_get_document_value(&doc! {"a": { "b": { "c": 1 }}}, "a.b.c"),
+            Some(Bson::Int32(1))
+        );
+        assert_eq!(
+            super::try_get_document_value(&doc! {"a": { "b": { "c": 1 }}}, "a.b.d"),
+            None
+        );
     }
 
     #[test]
@@ -294,7 +364,10 @@ mod tests {
             Bson::Undefined,
             Bson::Null,
             Bson::Boolean(true),
-            Bson::Timestamp(Timestamp { time: 42, increment: 42 }),
+            Bson::Timestamp(Timestamp {
+                time: 42,
+                increment: 42,
+            }),
             Bson::DateTime(super::bson_datetime_now()),
         ];
         let stacked = stacked_key(&values).unwrap();
@@ -306,5 +379,4 @@ mod tests {
             assert_eq!(slices[i], values[i]);
         }
     }
-
 }

--- a/src/polodb_core/vm/codegen.rs
+++ b/src/polodb_core/vm/codegen.rs
@@ -466,23 +466,14 @@ impl Codegen {
             let path_msg = format!("[{}]", index);
             crate::path_hint!(self, path_msg, {
                 let item_doc = crate::try_unwrap_document!("$and", item_doc_value);
-                self.emit_standard_query_doc(
-                    item_doc,
-                    result_label,
-
-                    not_found_label,
-                )?;
+                self.emit_standard_query_doc(item_doc, result_label, not_found_label)?;
             });
         }
 
         Ok(())
     }
 
-    fn emit_logic_or(
-        &mut self,
-        arr: &Array,
-        ret_label: Label,
-    ) -> Result<()> {
+    fn emit_logic_or(&mut self, arr: &Array, ret_label: Label) -> Result<()> {
         let cmp_label = self.new_label();
         self.emit_goto(DbOp::Goto, cmp_label);
 
@@ -496,11 +487,7 @@ impl Codegen {
                 let ret_label = self.new_label();
 
                 self.emit_label(query_label);
-                self.emit_standard_query_doc(
-                    item_doc,
-                    ret_label,
-                    ret_label
-                )?;
+                self.emit_standard_query_doc(item_doc, ret_label, ret_label)?;
 
                 self.emit_label(ret_label);
                 self.emit_ret(0);
@@ -532,19 +519,12 @@ impl Codegen {
             match key {
                 "$and" => {
                     let sub_arr = crate::try_unwrap_array!("$and", value);
-                    self.emit_logic_and(
-                        sub_arr.as_ref(),
-                        result_label,
-                        not_found_label,
-                    )?;
+                    self.emit_logic_and(sub_arr.as_ref(), result_label, not_found_label)?;
                 }
 
                 "$or" => {
                     let sub_arr = crate::try_unwrap_array!("$or", value);
-                    self.emit_logic_or(
-                        sub_arr.as_ref(),
-                        not_found_label,
-                    )?;
+                    self.emit_logic_or(sub_arr.as_ref(), not_found_label)?;
                 }
 
                 _ => {
@@ -557,12 +537,7 @@ impl Codegen {
         } else {
             match value {
                 Bson::Document(doc) => {
-                    return self.emit_query_tuple_document(
-                        key,
-                        doc,
-                        false,
-                        not_found_label,
-                    );
+                    return self.emit_query_tuple_document(key, doc, false, not_found_label);
                 }
 
                 Bson::Array(_) => {
@@ -811,6 +786,30 @@ impl Codegen {
                 });
             }
 
+            "$all" => {
+                match sub_value {
+                    Bson::Array(_) => (),
+                    _ => {
+                        return Err(Error::InvalidField(mk_invalid_query_field(
+                            self.last_key().into(),
+                            self.gen_path(),
+                        )))
+                    }
+                }
+
+                let field_size = self.recursively_get_field(key, not_found_label);
+
+                let stat_val_id = self.push_static(sub_value.clone());
+                self.emit_push_value(stat_val_id);
+
+                self.emit_logical(DbOp::All, is_in_not);
+
+                // if not equal，go to next
+                self.emit_goto(DbOp::IfFalse, not_found_label);
+
+                self.emit(DbOp::Pop2);
+                self.emit_u32((field_size + 1) as u32);
+            }
             _ => {
                 return Err(Error::InvalidField(mk_invalid_query_field(
                     self.last_key().into(),

--- a/src/polodb_core/vm/op.rs
+++ b/src/polodb_core/vm/op.rs
@@ -220,6 +220,7 @@ pub enum DbOp {
     // check if top0 is in top2
     // the result is stored in r0
     In,
+    All,
 
     EqualNull,
 

--- a/src/polodb_core/vm/subprogram.rs
+++ b/src/polodb_core/vm/subprogram.rs
@@ -1,27 +1,16 @@
-// Copyright 2024 Vincent Chan
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 use std::cell::RefCell;
 use super::label::LabelSlot;
 use super::op::DbOp;
 use crate::coll::collection_info::{CollectionSpecification, IndexInfo};
 use crate::errors::FieldTypeUnexpectedStruct;
 use crate::utils::str::escape_binary_to_string;
+use crate::vm::aggregation_codegen_context::AggregationCodeGenContext;
 use crate::vm::codegen::Codegen;
+use crate::vm::global_variable::GlobalVariableSlot;
 use crate::Result;
 use bson::{Bson, Document};
 use indexmap::IndexMap;
+use std::cell::RefCell;
 use std::fmt;
 use std::rc::Rc;
 use crate::errors::FieldTypeUnexpectedStruct;
@@ -386,7 +375,6 @@ fn open_bson_to_str(val: &Bson) -> Result<String> {
 
 impl fmt::Display for SubProgram {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-
         for (index, global_var) in self.global_variables.iter().enumerate() {
             writeln!(f, "${} = {:?}", index, global_var.init_value)?;
         }
@@ -1465,15 +1453,18 @@ mod tests {
     #[test]
     fn test_aggregate_match() {
         let col_spec = new_spec("test");
-        let program = SubProgram::compile_aggregate(&col_spec, vec![
-            doc! {
+        let program = SubProgram::compile_aggregate(
+            &col_spec,
+            vec![doc! {
                 "$match": {
                     "age": {
                         "$gt": 18
                     },
                 },
-            },
-        ], false).unwrap();
+            }],
+            false,
+        )
+        .unwrap();
         let actual = format!("Program:\n\n{}", program);
         let expect = r#"Program:
 
@@ -1519,18 +1510,23 @@ mod tests {
     #[test]
     fn test_aggregate_count() {
         let col_spec = new_spec("test");
-        let program = SubProgram::compile_aggregate(&col_spec, vec![
-            doc! {
-                "$match": {
-                    "age": {
-                        "$gt": 18
+        let program = SubProgram::compile_aggregate(
+            &col_spec,
+            vec![
+                doc! {
+                    "$match": {
+                        "age": {
+                            "$gt": 18
+                        },
                     },
                 },
-            },
-            doc! {
-                "$count": "total",
-            },
-        ], false).unwrap();
+                doc! {
+                    "$count": "total",
+                },
+            ],
+            false,
+        )
+        .unwrap();
         let actual = format!("Program:\n\n{}", program);
 
         let expect = r#"Program:
@@ -1606,11 +1602,14 @@ mod tests {
     #[test]
     fn test_aggregate_count_without_match() {
         let col_spec = new_spec("test");
-        let program = SubProgram::compile_aggregate(&col_spec, vec![
-            doc! {
+        let program = SubProgram::compile_aggregate(
+            &col_spec,
+            vec![doc! {
                 "$count": "total",
-            },
-        ], false).unwrap();
+            }],
+            false,
+        )
+        .unwrap();
         let actual = format!("Program:\n\n{}", program);
         let expect = r#"Program:
 
@@ -1661,7 +1660,6 @@ mod tests {
 "#;
         assert_eq!(expect, actual);
     }
-<<<<<<< HEAD
     #[test]
     fn test_aggregate_error_message() {
         let col_spec = new_spec("test");
@@ -1684,7 +1682,7 @@ mod tests {
                 panic!("Should return error");
             }
         }
-=======
+    }
 
     #[test]
     fn print_all() {
@@ -1737,6 +1735,5 @@ mod tests {
 "#;
 
         assert_eq!(expect, actual);
->>>>>>> 08915ab (start implementing)
     }
 }

--- a/src/polodb_core/vm/subprogram.rs
+++ b/src/polodb_core/vm/subprogram.rs
@@ -1731,7 +1731,7 @@ mod tests {
 105: Pop2(2)
 
 110: Label(1, "compare_function_clean")
-115: Ret(0)
+115: Ret0
 "#;
 
         assert_eq!(expect, actual);

--- a/src/polodb_core/vm/subprogram.rs
+++ b/src/polodb_core/vm/subprogram.rs
@@ -1727,7 +1727,7 @@ mod tests {
 
 80: Label(0, "compare_function")
 85: GetField("name", 110)
-94: PushValue(//^Vincent//)
+94: PushValue(["Vincent", "Antoine"])
 99: All
 100: FalseJump(110)
 105: Pop2(2)

--- a/src/polodb_core/vm/vm.rs
+++ b/src/polodb_core/vm/vm.rs
@@ -454,7 +454,8 @@ impl VM {
             self.stack[frame.stack_begin_pos + i] = self.stack[clone_start_pos + i].clone();
         }
 
-        self.stack.resize(frame.stack_begin_pos + return_size, Bson::Null);
+        self.stack
+            .resize(frame.stack_begin_pos + return_size, Bson::Null);
 
         self.reset_location(frame.return_pos as u32);
     }
@@ -878,12 +879,8 @@ impl VM {
                         self.pc = self.pc.add(1);
                     }
 
-                    DbOp::Not =>{
-                        self.r0 = if self.r0 == 0 {
-                            1
-                        } else {
-                            0
-                        };
+                    DbOp::Not => {
+                        self.r0 = if self.r0 == 0 { 1 } else { 0 };
 
                         self.pc = self.pc.add(1);
                     }
@@ -1003,7 +1000,8 @@ impl VM {
 
                     DbOp::IfFalseRet => {
                         let return_size = self.pc.add(1).cast::<u32>().read() as usize;
-                        if self.r0 == 0 {  // false
+                        if self.r0 == 0 {
+                            // false
                             self.ret(return_size);
                         } else {
                             self.pc = self.pc.add(5);
@@ -1026,6 +1024,28 @@ impl VM {
                         self.r1 = None;
                         self.state = VmState::Halt;
                         return Ok(());
+                    }
+
+                    DbOp::All => {
+                        let cmp_arr = &self.stack[self.stack.len() - 1];
+                        let db_arr = &self.stack[self.stack.len() - 2].as_array().unwrap();
+
+                        self.r0 = 0;
+
+                        let mut found_all = true;
+                        for item in cmp_arr.as_array().unwrap().iter() {
+                            // * all element must be in db_arr unlike $in
+                            if !db_arr.contains(item) {
+                                found_all = false;
+                                break;
+                            }
+                        }
+
+                        if found_all {
+                            self.r0 = 1;
+                        }
+
+                        self.pc = self.pc.add(1);
                     }
                 }
             }

--- a/src/polodb_core/vm/vm.rs
+++ b/src/polodb_core/vm/vm.rs
@@ -14,11 +14,13 @@
 
 use crate::cursor::Cursor;
 use crate::errors::{
-    FieldTypeUnexpectedStruct, RegexError, UnexpectedTypeForOpStruct,
+    AllError, FieldTypeUnexpectedStruct, RegexError, UnexpectedTypeForOpStruct,
 };
-use crate::index::{IndexHelper, IndexHelperOperation};
 use crate::transaction::TransactionInner;
 use crate::vm::op::{generic_cmp, DbOp};
+use crate::index::{IndexHelper, IndexHelperOperation};
+use crate::session::SessionInner;
+use crate::utils::bson::ElementType;
 use crate::vm::SubProgram;
 use crate::{Error, Metrics, Result};
 use bson::{Bson, Document};
@@ -1028,7 +1030,18 @@ impl VM {
 
                     DbOp::All => {
                         let cmp_arr = &self.stack[self.stack.len() - 1];
-                        let db_arr = &self.stack[self.stack.len() - 2].as_array().unwrap();
+                        println!("{:?}", self.stack);
+                        let db_arr =
+                            &self.stack[self.stack.len() - 2]
+                                .as_array()
+                                .ok_or(Error::from(AllError {
+                                    field_key: String::new(), // todo: use key field
+                                    field_type: ElementType::from(
+                                        self.stack[self.stack.len() - 2].element_type(),
+                                    )
+                                    .to_string(),
+                                    field_value: self.stack[self.stack.len() - 2].to_string(),
+                                }))?;
 
                         self.r0 = 0;
 

--- a/src/polodb_core/vm/vm.rs
+++ b/src/polodb_core/vm/vm.rs
@@ -473,7 +473,7 @@ impl VM {
             Some(Bson::Double(d)) => {
                 *d += 1.0;
             }
-            _ => ()
+            _ => (),
         }
     }
 
@@ -626,7 +626,7 @@ impl VM {
                                     0
                                 }
                             }
-                            _ => panic!("store r0 failed")
+                            _ => panic!("store r0 failed"),
                         };
                         self.pc = self.pc.add(1);
                     }
@@ -1030,7 +1030,6 @@ impl VM {
 
                     DbOp::All => {
                         let cmp_arr = &self.stack[self.stack.len() - 1];
-                        println!("{:?}", self.stack);
                         let db_arr =
                             &self.stack[self.stack.len() - 2]
                                 .as_array()


### PR DESCRIPTION
# Add MongoDB `$all` query filter

## TODO
- [x] implement `$all`
  - [x] Add `DbOp::All`
  - [x] Implement `$all` match in `codegen.rs`
  - [x] Implement `$all` match in `vm.rs`
  - [x] Implement `Error::AllError` - Should I implement some ?
  - [x] Implement `$all` match in `subprogram.rs`
- [x] implement unit tests