### PR TITLE
Update Cargo.toml

### DIFF
--- a/src/polodb_core/Cargo.toml
+++ b/src/polodb_core/Cargo.toml
@@ -26,7 +26,6 @@ uuid = { version = "1.3.0", features = [
     "atomic",
     "v1",
     "v4",
-    "wasm-bindgen",
     "js",
     "rng",
 ] }


### PR DESCRIPTION
remove `wasm-bindgen` feature from `uuid` crate, causes build fail