### PR TITLE
feat: add update options

### DIFF
--- a/src/polodb_core/coll/txn_collection.rs
+++ b/src/polodb_core/coll/txn_collection.rs
@@ -17,6 +17,7 @@ use std::sync::Weak;
 use bson::Document;
 use serde::Serialize;
 use crate::db::db_inner::DatabaseInner;
+use crate::options::UpdateOptions;
 use serde::de::DeserializeOwned;
 use crate::{CollectionT, Error, IndexModel, Result};
 use crate::action::{Aggregate, Find};
@@ -60,6 +61,19 @@ impl<T> CollectionT<T> for TransactionalCollection<T> {
             &self.name,
             Some(&query),
             &update,
+            UpdateOptions::default(),
+            &self.txn,
+        )?;
+        Ok(result)
+    }
+
+    fn update_one_with_options(&self, query: Document, update: Document, options: UpdateOptions) -> crate::Result<UpdateResult> {
+        let db = self.db.upgrade().ok_or(Error::DbIsClosed)?;
+        let result = db.update_one(
+            &self.name,
+            Some(&query),
+            &update,
+            options,
             &self.txn,
         )?;
         Ok(result)
@@ -67,7 +81,25 @@ impl<T> CollectionT<T> for TransactionalCollection<T> {
 
     fn update_many(&self, query: Document, update: Document) -> crate::Result<UpdateResult> {
         let db = self.db.upgrade().ok_or(Error::DbIsClosed)?;
-        let result = db.update_many(&self.name, query, update, &self.txn)?;
+        let result = db.update_many(
+            &self.name,
+            query,
+            update,
+            UpdateOptions::default(),
+            &self.txn,
+        )?;
+        Ok(result)
+    }
+
+    fn update_many_with_options(&self, query: Document, update: Document, options: UpdateOptions) -> Result<UpdateResult> {
+        let db = self.db.upgrade().ok_or(Error::DbIsClosed)?;
+        let result = db.update_many(
+            &self.name,
+            query,
+            update,
+            options,
+            &self.txn,
+        )?;
         Ok(result)
     }
 

--- a/src/polodb_core/errors.rs
+++ b/src/polodb_core/errors.rs
@@ -274,6 +274,8 @@ pub enum Error {
     InvalidAggregationStage(Box<Document>),
     #[error("rocks db error: {0}")]
     RocksDbErr(String),
+    #[error("$set value is not a document")]
+    SetIsNotADocument,
 }
 
 impl Error {

--- a/src/polodb_core/lib.rs
+++ b/src/polodb_core/lib.rs
@@ -147,6 +147,7 @@ mod meta_doc_helper;
 mod config;
 mod macros;
 mod transaction;
+pub mod options;
 pub mod results;
 
 pub mod test_utils;

--- a/src/polodb_core/options.rs
+++ b/src/polodb_core/options.rs
@@ -1,0 +1,57 @@
+// Copyright 2024 Vincent Chan
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Debug, Clone)]
+pub struct UpdateOptions {
+    pub upsert: Option<bool>,
+}
+
+impl UpdateOptions {
+    pub fn builder() -> UpdateOptionsBuilder {
+        UpdateOptionsBuilder::default()
+    }
+
+    pub(crate) fn is_upsert(&self) -> bool {
+        self.upsert.unwrap_or(false)
+    }
+}
+
+pub struct UpdateOptionsBuilder {
+    upsert: Option<bool>,
+}
+
+impl UpdateOptionsBuilder {
+    pub fn upsert(mut self, upsert: bool) -> Self {
+        self.upsert = Some(upsert);
+        self
+    }
+
+    pub fn build(self) -> UpdateOptions {
+        UpdateOptions {
+            upsert: self.upsert,
+        }
+    }
+}
+
+impl Default for UpdateOptionsBuilder {
+    fn default() -> Self {
+        UpdateOptionsBuilder { upsert: None }
+    }
+}
+
+impl Default for UpdateOptions {
+    fn default() -> Self {
+        UpdateOptions { upsert: None }
+    }
+}


### PR DESCRIPTION

Implement: #130

```rust
// Attempt to update a non-existent document with upsert
    let update_result = col.update_one_with_options(
        doc! { "_id": 1 },
        doc! { "$set": { "name": "John", "age": 30 } },
        UpdateOptions::builder().upsert(true).build(),
    ).unwrap();
 ```