### PR TITLE
feat: add ping handler

### DIFF
--- a/src/polodb/handlers/mod.rs
+++ b/src/polodb/handlers/mod.rs
@@ -8,6 +8,7 @@ mod delete_handler;
 mod commit_transaction;
 mod abort_transaction;
 mod aggregate_handler;
+mod ping_handler;
 
 use std::sync::Arc;
 use bson::RawDocumentBuf;
@@ -26,6 +27,7 @@ pub(crate) use delete_handler::DeleteHandler;
 pub(crate) use commit_transaction::CommitTransactionHandler;
 pub(crate) use abort_transaction::AbortTransactionHandler;
 pub(crate) use aggregate_handler::AggregateHandle;
+pub(crate) use ping_handler::PingHandler;
 use crate::app_context::AppContext;
 use crate::session_context::SessionContext;
 
@@ -60,5 +62,6 @@ pub(crate) fn make_handlers() -> Vec<Arc<dyn Handler>> {
         HelloHandler::new(),
         CommitTransactionHandler::new(),
         AbortTransactionHandler::new(),
+        PingHandler::new(),
     ]
 }

--- a/src/polodb/handlers/ping_handler.rs
+++ b/src/polodb/handlers/ping_handler.rs
@@ -1,0 +1,47 @@
+// Copyright 2024 Vincent Chan
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::handlers::{HandleContext, Handler};
+use crate::reply::Reply;
+use anyhow::Result;
+use async_trait::async_trait;
+use bson::{rawdoc, RawDocumentBuf};
+use log::debug;
+use std::sync::Arc;
+
+pub(crate) struct PingHandler {}
+
+impl PingHandler {
+    pub(crate) fn new() -> Arc<dyn Handler> {
+        Arc::new(PingHandler {})
+    }
+}
+
+#[async_trait]
+impl Handler for PingHandler {
+    fn test(&self, doc: &RawDocumentBuf) -> Result<bool> {
+        let val = doc.get("ping")?;
+        Ok(val.is_some())
+    }
+
+    async fn handle(&self, ctx: &HandleContext) -> Result<Reply> {
+        let req_id = ctx.message.request_id.unwrap();
+        debug!("PingHandler::handle {}", req_id);
+        let body = rawdoc! {
+            "ok": 1
+        };
+        let reply = Reply::new(req_id, body);
+        Ok(reply)
+    }
+}


### PR DESCRIPTION
This pull request adds a new command:

`db.runCommand({ ping: 1})`

will reply a document back:

`{ ok: 1 }`

Some MongoDB clients, like `mongosh` use this command to check whether the server is working or not.