### PR TITLE
fix: bump minimum wire version to 7 and handle ismaster requests

### DIFF
--- a/src/polodb/handlers/hello_handler.rs
+++ b/src/polodb/handlers/hello_handler.rs
@@ -33,7 +33,9 @@ impl HelloHandler {
 #[async_trait]
 impl Handler for HelloHandler {
     fn test(&self, doc: &RawDocumentBuf) -> Result<bool> {
-        Ok(doc.get("helloOk")?.is_some() || doc.get("ismaster")?.is_some())
+        Ok(doc.get("helloOk")?.is_some()
+            || doc.get("ismaster")?.is_some()
+            || doc.get("isMaster")?.is_some())
     }
 
     async fn handle(&self, ctx: &HandleContext) -> Result<Reply> {


### PR DESCRIPTION
Wire version `6` uses the `OP_REPLY` and related deprecated legacy messages:
https://www.mongodb.com/docs/manual/legacy-opcodes/

PoloDB does not support these messages, so it doesn't make sense for us to advertise wire version 6 compatibility. Wire version 7 adds support for `OP_MSG` messages that PoloDB uses.

Also extend the `HelloHandler` to handle `ismaster` requests, often used by the `mongosh` tool.