### PR TITLE
Fix CI, PyO3 bindings, and release safeguards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,88 +2,189 @@ name: Build Release
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to build and publish (for example, v5.1.4)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ inputs.tag }}
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTUP_TOOLCHAIN: stable
 
 jobs:
+  prepare:
+    name: Resolve release tag
+    runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.resolve.outputs.commit }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve tag to commit
+        id: resolve
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          tag_ref="refs/tags/$RELEASE_TAG"
+          if ! git show-ref --verify --quiet "$tag_ref"; then
+            echo "Tag does not exist: $RELEASE_TAG"
+            exit 1
+          fi
+          commit="$(git rev-parse "$tag_ref^{commit}")"
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
   MacOS:
     name: Build on MacOS
-    permissions: write-all
-    runs-on: macos-latest
+    needs: prepare
+    # Keep the published darwin-x64 artifact on an Intel runner. macos-latest is arm64.
+    runs-on: macos-15-intel
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
+          ref: ${{ needs.prepare.outputs.commit }}
           submodules: recursive
-          token: ${{ secrets.PAT_TOKEN }}
-      - uses: actions/setup-node@v2
+
+      - uses: actions/cache@v5
         with:
-          node-version: '18'
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-release-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run Rust tests
-        run: cargo test --release --verbose --workspace
-      - name: Build Clib
-        run: cargo build --release
+        run: cargo test --locked --release --verbose --workspace --exclude py-binding-polodb
+      - name: Build CLI
+        run: cargo build --locked --release --package polodb --bin polodb
       - name: Copy files
         run: |
           cp target/release/polodb polodb-darwin-x64
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v7
         with:
-          files: |
-            polodb-darwin-x64
+          name: release-darwin-x64
+          path: polodb-darwin-x64
+          if-no-files-found: error
 
   Ubuntu:
     name: Build on Ubuntu
-    permissions: write-all
+    needs: prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
+          ref: ${{ needs.prepare.outputs.commit }}
           submodules: recursive
-          token: ${{ secrets.PAT_TOKEN }}
-      - uses: actions/setup-node@v2
+
+      - uses: actions/cache@v5
         with:
-          node-version: '18'
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-release-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run Rust tests
-        run: cargo test --release --verbose --workspace
-      - name: Build Clib
-        run: cargo build --release
+        run: cargo test --locked --release --verbose --workspace --exclude py-binding-polodb
+      - name: Build CLI
+        run: cargo build --locked --release --package polodb --bin polodb
       - name: Copy files
         run: |
           cp target/release/polodb polodb-linux-x64
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v7
         with:
-          files: |
-            polodb-linux-x64
+          name: release-linux-x64
+          path: polodb-linux-x64
+          if-no-files-found: error
 
   Windows:
     name: Build on Windows
-    permissions: write-all
+    needs: prepare
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
+          ref: ${{ needs.prepare.outputs.commit }}
           submodules: recursive
-          token: ${{ secrets.PAT_TOKEN }}
-      - uses: actions/setup-node@v2
+
+      - uses: actions/cache@v5
         with:
-          node-version: '18'
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-release-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run Rust tests
-        run: cargo test --release --verbose --workspace
-      - name: Build Clib
-        run: cargo build --release
+        run: cargo test --locked --release --verbose --workspace --exclude py-binding-polodb
+      - name: Build CLI
+        run: cargo build --locked --release --package polodb --bin polodb
       - name: Copy files
         run: |
           Copy-Item "target/release/polodb.exe" -Destination "polodb-win32-x64.exe"
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v7
         with:
-          files: |
-            polodb-win32-x64.exe
+          name: release-win32-x64
+          path: polodb-win32-x64.exe
+          if-no-files-found: error
+
+  Publish:
+    name: Publish GitHub Release
+    needs: [prepare, MacOS, Ubuntu, Windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.commit }}
+
+      - name: Verify tag still points to the built commit
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          EXPECTED_COMMIT: ${{ needs.prepare.outputs.commit }}
+        run: |
+          tag_ref="refs/tags/$RELEASE_TAG"
+          git fetch --force --tags origin
+          actual_commit="$(git rev-parse "$tag_ref^{commit}")"
+          if [[ "$actual_commit" != "$EXPECTED_COMMIT" ]]; then
+            echo "Tag moved during the build: $RELEASE_TAG"
+            echo "Expected: $EXPECTED_COMMIT"
+            echo "Actual:   $actual_commit"
+            exit 1
+          fi
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: release-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Publish release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: release-assets/*
+          fail_on_unmatched_files: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,79 +2,159 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTUP_TOOLCHAIN: stable
 
 jobs:
-  Ubuntu:
-    name: Test on Ubuntu
+  rust-core:
+    name: Rust Core (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu
+            os: ubuntu-latest
+          - name: macOS
+            os: macos-latest
+          - name: Windows
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run Rust tests
+        run: cargo test --locked --release --verbose --workspace --exclude py-binding-polodb
+
+      - name: Build Rust workspace
+        run: cargo build --locked --release --workspace --exclude py-binding-polodb
+
+  python-bindings:
+    name: Python Bindings (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-python-${{ matrix.python-version }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install Python tooling
+        working-directory: py-polodb
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          python -m pip install "maturin>=1.9.4,<2" pytest
+
+      - name: Build and install Python wheel
+        working-directory: py-polodb
+        run: |
+          source .venv/bin/activate
+          maturin build --locked --release --out "${{ runner.temp }}/wheels"
+          python -m pip install --force-reinstall "${{ runner.temp }}"/wheels/*.whl
+
+      - name: Smoke test installed package
+        working-directory: ${{ runner.temp }}
+        run: |
+          source "$GITHUB_WORKSPACE/py-polodb/.venv/bin/activate"
+          python -c "from polodb import Collection, PoloDB"
+
+      - name: Run Python tests
+        working-directory: ${{ runner.temp }}
+        run: |
+          source "$GITHUB_WORKSPACE/py-polodb/.venv/bin/activate"
+          cp -R "$GITHUB_WORKSPACE/py-polodb/tests" python-tests
+          python -m pytest python-tests
+
+  python-bindings-msrv:
+    name: Python Bindings (Rust 1.83 MSRV)
+    runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: 1.83.0
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install Rust 1.83
+        run: rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-rust-1.83-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check Python bindings at their Rust MSRV
+        run: cargo check --locked -p py-binding-polodb
+
+  required-ci-gate:
+    name: Rust / Required CI Gate
+    if: ${{ always() }}
+    needs:
+      - rust-core
+      - python-bindings
+      - python-bindings-msrv
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Run Rust tests
-        run: RUST_BACKTRACE=1 cargo test --release --verbose --workspace
-      - name: Build binaries
-        run: cargo build --release
-
-  MacOS:
-    name: Test on MacOS
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Run Rust tests
-        run: RUST_BACKTRACE=1 cargo test --release --verbose --workspace
-      - name: Build Clib
-        run: cargo build --release
-
-  Windows:
-    name: Test on Windows
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Run Rust tests
-        run: cargo test --release --verbose --workspace
+      - name: Verify required jobs succeeded
         env:
-          RUST_BACKTRACE: 1
-      - name: Build binaries
-        run: cargo build --release
+          RUST_CORE_RESULT: ${{ needs.rust-core.result }}
+          PYTHON_BINDINGS_RESULT: ${{ needs.python-bindings.result }}
+          PYTHON_BINDINGS_MSRV_RESULT: ${{ needs.python-bindings-msrv.result }}
+        run: |
+          if [[ "$RUST_CORE_RESULT" != "success" || "$PYTHON_BINDINGS_RESULT" != "success" || "$PYTHON_BINDINGS_MSRV_RESULT" != "success" ]]; then
+            echo "Rust Core result: $RUST_CORE_RESULT"
+            echo "Python Bindings result: $PYTHON_BINDINGS_RESULT"
+            echo "Python Bindings MSRV result: $PYTHON_BINDINGS_MSRV_RESULT"
+            exit 1
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,12 +905,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
-
-[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,15 +1074,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "parking_lot"
@@ -1308,7 +1293,6 @@ dependencies = [
  "libz-sys",
  "lz4-sys",
  "pkg-config",
- "pyo3-build-config",
  "tikv-jemalloc-sys",
  "uuid",
  "zstd-sys",
@@ -1377,37 +1361,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d922163ba1f79c04bc49073ba7b32fd5a8d3b76a87c955921234b8e77333c51"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc38c5feeb496c8321091edf3d63e9a6829eab4b863b4a6a65f26f3e9cc6b179"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94845622d88ae274d2729fcefc850e63d7a3ddff5e3ce11bd88486db9f1d357d"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1415,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e655aad15e09b94ffdb3ce3d217acf652e26bbc37697ef012f5e5e348c716e5e"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1427,13 +1406,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1e3f09eecd94618f60a455a23def79f79eba4dc561a97324bf9ac8c6df30ce"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.74",
 ]
@@ -1446,9 +1424,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1916,9 +1894,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "termcolor"
@@ -2183,12 +2161,6 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "unindent"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "untrusted"

--- a/py-polodb/Cargo.toml
+++ b/py-polodb/Cargo.toml
@@ -6,6 +6,7 @@ name = "py-binding-polodb"
 # these are good defaults:
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.83"
 
 [lib]
 # The name of the native library. This is the name which will be used in Python to import the
@@ -19,4 +20,4 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # polodb_core = "5.1.0"
 polodb_core = { path = "../src/polodb_core", default-features = false  }
-pyo3 = { version = "0.22.5", features = ["extension-module", "auto-initialize"] }
+pyo3 = "0.29.0"

--- a/py-polodb/polodb/core.py
+++ b/py-polodb/polodb/core.py
@@ -1,4 +1,4 @@
-from rust_polodb import PyDatabase, PyCollection
+from .rust_polodb import PyDatabase, PyCollection
 from typing import List
 
 
@@ -40,7 +40,7 @@ class Collection:
     def insert_one(self, entry: dict):
         return self.__rust_collection.insert_one(entry)
 
-    def insert_many(self, entry: dict):
+    def insert_many(self, entry: List[dict]):
         return self.__rust_collection.insert_many(entry)
 
     def find_one(self, filter: dict):

--- a/py-polodb/pyproject.toml
+++ b/py-polodb/pyproject.toml
@@ -1,3 +1,18 @@
+[project]
+name = "polodb"
+version = "0.1.0"
+description = "Python bindings for the embedded PoloDB document database"
+readme = "README.md"
+requires-python = ">=3.12"
+authors = [
+    { name = "SENHAJI RHAZI Hamza", email = "hamza.senhajirhazi@gmail.com" },
+]
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+
 [tool.poetry]
 name = "polodb"
 version = "0.1.0"
@@ -25,8 +40,12 @@ ipdb = "^0.13.13"
 
 
 [build-system]
-requires = ["poetry-core", "maturin>=1,<2"]
+requires = ["maturin>=1.9.4,<2"]
 build-backend = "maturin"
+
+[tool.maturin]
+python-source = "."
+module-name = "polodb.rust_polodb"
 
 [tool.poetry.scripts]
 build-rust = "maturin develop"

--- a/py-polodb/src/helper_type_translator.rs
+++ b/py-polodb/src/helper_type_translator.rs
@@ -3,101 +3,66 @@ use polodb_core::results;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use pyo3::types::{PyAny, PyBool, PyBytes, PyFloat, PyList, PyString};
+use pyo3::IntoPyObjectExt;
 
-pub fn convert_py_list_to_vec_document<'a>(py_list_obj: &'a Py<PyAny>) -> Vec<Document> {
-    Python::with_gil(|py| {
-        // Try to downcast the PyAny to a PyList
-        if let Ok(py_list) = py_list_obj.downcast_bound::<PyList>(py) {
-            // If downcast is successful, return an iterator over the list's items
-            let iter = py_list.iter().map(|item| {
-                let py_obj: Py<PyAny> = item.to_object(item.py());
-                // Convert each item (expected to be a dictionary) into a BSON document
-
-                convert_py_obj_to_document(&py_obj).unwrap()
-            });
-            Vec::from_iter(iter)
-        } else {
-            Vec::from_iter(std::iter::empty())
-        }
-    })
+pub fn convert_py_list_to_vec_document(py_list: &Bound<'_, PyList>) -> PyResult<Vec<Document>> {
+    py_list
+        .iter()
+        .map(|item| convert_py_obj_to_document(item.as_any()))
+        .collect()
 }
 
-pub fn convert_py_obj_to_document(py_obj: &Py<PyAny>) -> PyResult<Document> {
-    Python::with_gil(|py| {
-        // Try to extract as a String and convert to BSON
-        //    let mut doc: Document = Document::new();
-        if let Ok(dict) = py_obj.downcast_bound::<PyDict>(py) {
-            // let dict_ref = dict.borrow(); // Convert Py<PyDict> to &PyDict
-            let mut doc = Document::new();
-            for (key, value) in dict.iter() {
-                // Use `iter()` on the `PyDict`
-                let key: String = key.extract()?; // Extract the key as a string
-                let bson_value = convert_py_obj_to_bson(value.to_object(py).as_any())?; // Convert value to BSON
-                doc.insert(key, bson_value);
-            }
-            Ok(doc)
+pub fn convert_py_obj_to_document(py_obj: &Bound<'_, PyAny>) -> PyResult<Document> {
+    if let Ok(dict) = py_obj.cast::<PyDict>() {
+        let mut doc = Document::new();
+        for (key, value) in dict.iter() {
+            let key: String = key.extract()?;
+            let bson_value = convert_py_obj_to_bson(&value)?;
+            doc.insert(key, bson_value);
         }
-        // If the type is not supported, return an error
-        else {
-            Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                "Unsupported Python type for BSON conversion",
-            ))
-        }
-    })
+        Ok(doc)
+    } else {
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "Unsupported Python type for BSON conversion",
+        ))
+    }
 }
 
-pub fn convert_py_obj_to_bson(py_obj: &Py<PyAny>) -> PyResult<Bson> {
-    Python::with_gil(|py| {
-        // Try to extract as a String and convert to BSON
-        if let Ok(rust_string) = py_obj.extract::<String>(py) {
-            Ok(Bson::String(rust_string))
+pub fn convert_py_obj_to_bson(py_obj: &Bound<'_, PyAny>) -> PyResult<Bson> {
+    if let Ok(rust_string) = py_obj.extract::<String>() {
+        Ok(Bson::String(rust_string))
+    } else if let Ok(rust_bool) = py_obj.extract::<bool>() {
+        Ok(Bson::Boolean(rust_bool))
+    } else if let Ok(rust_int) = py_obj.extract::<i64>() {
+        Ok(Bson::Int64(rust_int))
+    } else if let Ok(rust_float) = py_obj.extract::<f64>() {
+        Ok(Bson::Double(rust_float))
+    } else if let Ok(dict) = py_obj.cast::<PyDict>() {
+        let mut bson_doc = Document::new();
+        for (key, value) in dict.iter() {
+            let key_str: String = key.extract::<String>()?;
+            let bson_value = convert_py_obj_to_bson(&value)?;
+            bson_doc.insert(key_str, bson_value);
         }
-        // Try to extract as a bool and convert to BSON
-        else if let Ok(rust_bool) = py_obj.extract::<bool>(py) {
-            Ok(Bson::Boolean(rust_bool))
+        Ok(Bson::Document(bson_doc))
+    } else if let Ok(list) = py_obj.cast::<PyList>() {
+        let mut bson_array = Vec::new();
+        for item in list.iter() {
+            bson_array.push(convert_py_obj_to_bson(&item)?);
         }
-        // Try to extract as an int (i64) and convert to BSON
-        else if let Ok(rust_int) = py_obj.extract::<i64>(py) {
-            Ok(Bson::Int64(rust_int))
-        }
-        // Try to extract as a float and convert to BSON double
-        else if let Ok(rust_float) = py_obj.extract::<f64>(py) {
-            Ok(Bson::Double(rust_float))
-        }
-        // Try to extract as a dictionary and convert to BSON document
-        else if let Ok(dict) = py_obj.downcast_bound::<PyDict>(py) {
-            let mut bson_doc = Document::new();
-            for (key, value) in dict.iter() {
-                let key_str: String = key.extract::<String>()?;
-
-                let bson_value = convert_py_obj_to_bson(value.to_object(py).as_any())?;
-                bson_doc.insert(key_str, bson_value);
-            }
-            Ok(Bson::Document(bson_doc))
-        }
-        // Try to extract as a list and convert to BSON array
-        else if let Ok(list) = py_obj.downcast_bound::<PyList>(py) {
-            let mut bson_array = Vec::new();
-            for item in list.iter() {
-                let bson_item = convert_py_obj_to_bson(item.to_object(py).as_any())?;
-                bson_array.push(bson_item);
-            }
-            Ok(Bson::Array(bson_array))
-        }
-        // If the type is not supported, return an error
-        else {
-            Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                "Unsupported Python type for BSON conversion",
-            ))
-        }
-    })
+        Ok(Bson::Array(bson_array))
+    } else {
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "Unsupported Python type for BSON conversion",
+        ))
+    }
 }
 
 pub fn delete_result_to_pydict(
-    py: Python,
+    py: Python<'_>,
     delete_result: results::DeleteResult,
 ) -> PyResult<Py<PyDict>> {
-    let py_dict = PyDict::new_bound(py);
+    let py_dict = PyDict::new(py);
 
     // Insert matched_count and modified_count into the PyDict
     py_dict.set_item("deleted_count", delete_result.deleted_count as i64)?;
@@ -106,10 +71,10 @@ pub fn delete_result_to_pydict(
 }
 
 pub fn update_result_to_pydict(
-    py: Python,
+    py: Python<'_>,
     update_result: results::UpdateResult,
 ) -> PyResult<Py<PyDict>> {
-    let py_dict = PyDict::new_bound(py);
+    let py_dict = PyDict::new(py);
 
     // Insert matched_count and modified_count into the PyDict
     py_dict.set_item("matched_count", update_result.matched_count as i64)?;
@@ -117,8 +82,8 @@ pub fn update_result_to_pydict(
 
     Ok(py_dict.into())
 }
-pub fn document_to_pydict(py: Python, doc: Document) -> PyResult<Py<PyDict>> {
-    let py_dict = PyDict::new_bound(py);
+pub fn document_to_pydict(py: Python<'_>, doc: Document) -> PyResult<Py<PyDict>> {
+    let py_dict = PyDict::new(py);
     for (key, value) in doc {
         let py_value = bson_to_py_obj(py, &value);
         py_dict.set_item(key, py_value)?;
@@ -126,51 +91,48 @@ pub fn document_to_pydict(py: Python, doc: Document) -> PyResult<Py<PyDict>> {
     Ok(py_dict.into())
 }
 
-pub fn bson_to_py_obj(py: Python, bson: &Bson) -> PyObject {
+pub fn bson_to_py_obj(py: Python<'_>, bson: &Bson) -> Py<PyAny> {
     match bson {
         Bson::Null => py.None(),
-        Bson::Int32(i) => i.into_py(py),
-        Bson::Int64(i) => i.into_py(py),
-        Bson::Double(f) => PyFloat::new_bound(py, *f).into_py(py),
-        Bson::String(s) => PyString::new_bound(py, s).into_py(py),
-        Bson::Boolean(b) => PyBool::new_bound(py, *b).into_py(py),
+        Bson::Int32(i) => i.into_py_any(py).unwrap(),
+        Bson::Int64(i) => i.into_py_any(py).unwrap(),
+        Bson::Double(f) => PyFloat::new(py, *f).into_any().unbind(),
+        Bson::String(s) => PyString::new(py, s).into_any().unbind(),
+        Bson::Boolean(b) => PyBool::new(py, *b).to_owned().into_any().unbind(),
         Bson::Array(arr) => {
             // Create an empty PyList without specifying a slice
-            let py_list = PyList::empty_bound(py); // Use empty method instead of new_bound
+            let py_list = PyList::empty(py);
             for item in arr {
                 py_list.append(bson_to_py_obj(py, item)).unwrap();
             }
-            py_list.into_py(py)
+            py_list.into_any().unbind()
         }
         Bson::Document(doc) => {
-            let py_dict = PyDict::new_bound(py);
+            let py_dict = PyDict::new(py);
             for (key, value) in doc.iter() {
                 py_dict.set_item(key, bson_to_py_obj(py, value)).unwrap();
             }
-            py_dict.into_py(py)
+            py_dict.into_any().unbind()
         }
         Bson::RegularExpression(regex) => {
-            let re_module = py.import_bound("re").unwrap();
+            let re_module = py.import("re").unwrap();
             re_module
                 .call_method1("compile", (regex.pattern.as_str(),))
                 .unwrap()
-                .to_object(py)
+                .into_any()
+                .unbind()
         }
         // Handle JavaScript code
-        Bson::JavaScriptCode(code) => PyString::new_bound(py, code).into_py(py),
-        Bson::Timestamp(ts) => (ts.time, ts.increment).into_py(py),
-        Bson::Binary(bin) => PyBytes::new_bound(py, &bin.bytes).into_py(py),
-        Bson::ObjectId(oid) => PyString::new_bound(py, &oid.to_hex()).into_py(py),
+        Bson::JavaScriptCode(code) => PyString::new(py, code).into_any().unbind(),
+        Bson::Timestamp(ts) => (ts.time, ts.increment).into_py_any(py).unwrap(),
+        Bson::Binary(bin) => PyBytes::new(py, &bin.bytes).into_any().unbind(),
+        Bson::ObjectId(oid) => PyString::new(py, &oid.to_hex()).into_any().unbind(),
         Bson::DateTime(dt) => {
             let timestamp = dt.timestamp_millis() / 1000;
-            let datetime = py
-                .import_bound("datetime")
-                .unwrap()
-                .getattr("datetime")
-                .unwrap();
-            datetime.call1((timestamp,)).unwrap().to_object(py)
+            let datetime = py.import("datetime").unwrap().getattr("datetime").unwrap();
+            datetime.call1((timestamp,)).unwrap().into_any().unbind()
         }
-        Bson::Symbol(s) => PyString::new_bound(py, s).into_py(py),
+        Bson::Symbol(s) => PyString::new(py, s).into_any().unbind(),
 
         // Handle undefined value (deprecated)
         Bson::Undefined => py.None(),

--- a/py-polodb/src/lib.rs
+++ b/py-polodb/src/lib.rs
@@ -6,7 +6,7 @@ mod py_database;
 use py_database::PyCollection;
 use py_database::PyDatabase;
 
-#[pymodule]
+#[pymodule(gil_used = true)]
 fn rust_polodb(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // m.add_function(wrap_pyfunction!(sum_as_string, m)?);
     m.add_class::<PyDatabase>()?;

--- a/py-polodb/src/py_database.rs
+++ b/py-polodb/src/py_database.rs
@@ -3,12 +3,13 @@ use crate::helper_type_translator::{
     delete_result_to_pydict, document_to_pydict, update_result_to_pydict,
 };
 use polodb_core::bson::Document;
-use polodb_core::{results, Collection, CollectionT, Database};
+use polodb_core::{Collection, CollectionT, Database};
 use pyo3::exceptions::PyOSError;
 use pyo3::exceptions::PyRuntimeError; // Import PyRuntimeError for error handling
 use pyo3::prelude::*;
+use pyo3::types::PyAny;
 use pyo3::types::{PyDict, PyList};
-use std::borrow::Borrow;
+use pyo3::IntoPyObjectExt;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -25,20 +26,20 @@ impl PyCollection {
 
     pub fn update_one(
         &self,
-        py: Python,
+        py: Python<'_>,
         filter: Py<PyDict>,
         update: Py<PyDict>,
-    ) -> PyResult<Option<PyObject>> {
+    ) -> PyResult<Option<Py<PyAny>>> {
         // Convert PyDict to BSON Document
-        let filter_doc = convert_py_obj_to_document(filter.to_object(py).as_any())?;
-        let update_doc = convert_py_obj_to_document(update.to_object(py).as_any())?;
+        let filter_doc = convert_py_obj_to_document(filter.bind(py).as_any())?;
+        let update_doc = convert_py_obj_to_document(update.bind(py).as_any())?;
 
         // Call the Rust method `find_one`
         match self.inner.update_one(filter_doc, update_doc) {
             Ok(update_result) => {
                 // Convert BSON Document to Python Dict
                 let py_result = update_result_to_pydict(py, update_result).unwrap();
-                Ok(Some(py_result.to_object(py)))
+                Ok(Some(py_result.into_any()))
             }
             Err(err) => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
                 "Update one error: {}",
@@ -48,20 +49,20 @@ impl PyCollection {
     }
     pub fn update_many(
         &self,
-        py: Python,
+        py: Python<'_>,
         filter: Py<PyDict>,
         update: Py<PyDict>,
-    ) -> PyResult<Option<PyObject>> {
+    ) -> PyResult<Option<Py<PyAny>>> {
         // Convert PyDict to BSON Document
-        let filter_doc = convert_py_obj_to_document(filter.to_object(py).as_any())?;
-        let update_doc = convert_py_obj_to_document(update.to_object(py).as_any())?;
+        let filter_doc = convert_py_obj_to_document(filter.bind(py).as_any())?;
+        let update_doc = convert_py_obj_to_document(update.bind(py).as_any())?;
 
         // Call the Rust method `find_one`
         match self.inner.update_many(filter_doc, update_doc) {
             Ok(update_result) => {
                 // Convert BSON Document to Python Dict
                 let py_result = update_result_to_pydict(py, update_result).unwrap();
-                Ok(Some(py_result.to_object(py)))
+                Ok(Some(py_result.into_any()))
             }
             Err(err) => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
                 "Update many error: {}",
@@ -69,158 +70,100 @@ impl PyCollection {
             ))),
         }
     }
-    pub fn insert_many(&self, doc: Py<PyList>) -> PyResult<PyObject> {
-        // Acquire the Python GIL (Global Interpreter Lock)
-        Python::with_gil(|py| {
-            // Now you can use `py` inside this block.
-
-            // Example: Create a Python object or interact with the Python runtime.
-            let bson_vec_docs: Vec<Document> =
-                convert_py_list_to_vec_document(doc.to_object(py).as_any());
-            // let bson_doc = convert_py_to_bson(doc);
-            match self.inner.insert_many(bson_vec_docs) {
-                Ok(result) => {
-                    // Create a Python object from the Rust result and return it
-                    let dict: Bound<'_, PyDict> = PyDict::new_bound(py);
-
-                    for (key, value) in &result.inserted_ids {
-                        dict.set_item(key, bson_to_py_obj(py, value)).unwrap();
-                    }
-
-                    Ok(dict.to_object(py))
+    pub fn insert_many(&self, py: Python<'_>, doc: Py<PyList>) -> PyResult<Py<PyAny>> {
+        let bson_vec_docs = convert_py_list_to_vec_document(doc.bind(py))?;
+        match self.inner.insert_many(bson_vec_docs) {
+            Ok(result) => {
+                let dict = PyDict::new(py);
+                for (key, value) in &result.inserted_ids {
+                    dict.set_item(key, bson_to_py_obj(py, value))?;
                 }
-                Err(e) => {
-                    // Raise a Python exception on error
-                    Err(PyRuntimeError::new_err(format!("Insert many error: {}", e)))
-                }
+                Ok(dict.into_any().unbind())
             }
-        })
+            Err(e) => Err(PyRuntimeError::new_err(format!("Insert many error: {}", e))),
+        }
     }
 
-    pub fn count_documents(&self) -> PyResult<PyObject> {
-        // Acquire the Python GIL (Global Interpreter Lock)
-        Python::with_gil(|py| {
-            match self.inner.count_documents() {
-                Ok(result) => Ok(result.into_py(py)),
-                Err(e) => {
-                    // Raise a Python exception on error
-                    Err(PyRuntimeError::new_err(format!(
-                        "Count documents error: {}",
-                        e
-                    )))
-                }
-            }
-        })
+    pub fn count_documents(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        match self.inner.count_documents() {
+            Ok(result) => result.into_py_any(py),
+            Err(e) => Err(PyRuntimeError::new_err(format!(
+                "Count documents error: {}",
+                e
+            ))),
+        }
     }
 
-    pub fn insert_one(&self, doc: Py<PyDict>) -> PyResult<PyObject> {
-        // Acquire the Python GIL (Global Interpreter Lock)
-        Python::with_gil(|py| {
-            let bson_doc: Document = match convert_py_obj_to_document(doc.to_object(py).as_any()) {
-                Ok(d) => d,
-                Err(e) => return Err(PyRuntimeError::new_err(format!("Insert many error: {}", e))),
-            };
-            // let bson_doc = convert_py_to_bson(doc);
-            match self.inner.insert_one(bson_doc) {
-                Ok(result) => {
-                    // Create a Python object from the Rust result and return it
-                    let py_inserted_id = bson_to_py_obj(py, &result.inserted_id);
-                    let dict = PyDict::new_bound(py);
-                    let dict_ref = dict.borrow();
-                    dict_ref.set_item("inserted_id", py_inserted_id)?;
-                    Ok(dict.to_object(py))
-
-                    // Ok(Py::new(py, result)?.to_object(py))
-                }
-                Err(e) => {
-                    // Raise a Python exception on error
-                    Err(PyRuntimeError::new_err(format!("Insert error: {}", e)))
-                }
+    pub fn insert_one(&self, py: Python<'_>, doc: Py<PyDict>) -> PyResult<Py<PyAny>> {
+        let bson_doc: Document = match convert_py_obj_to_document(doc.bind(py).as_any()) {
+            Ok(d) => d,
+            Err(e) => return Err(PyRuntimeError::new_err(format!("Insert many error: {}", e))),
+        };
+        match self.inner.insert_one(bson_doc) {
+            Ok(result) => {
+                let py_inserted_id = bson_to_py_obj(py, &result.inserted_id);
+                let dict = PyDict::new(py);
+                dict.set_item("inserted_id", py_inserted_id)?;
+                Ok(dict.into_any().unbind())
             }
-        })
+            Err(e) => Err(PyRuntimeError::new_err(format!("Insert error: {}", e))),
+        }
     }
 
-    pub fn delete_one(&self, filter: Py<PyDict>) -> PyResult<PyObject> {
-        // Acquire the Python GIL (Global Interpreter Lock)
-        // let filter_doc = convert_py_obj_to_document(filter.to_object(py).as_any())?;
-        Python::with_gil(|py| {
-            let bson_doc: Document = match convert_py_obj_to_document(filter.to_object(py).as_any())
-            {
-                Ok(d) => d,
-                Err(e) => return Err(PyRuntimeError::new_err(format!("Delete one : {}", e))),
-            };
-            // let bson_doc = convert_py_to_bson(doc);
-            match self.inner.delete_one(bson_doc) {
-                Ok(delete_result) => {
-                    // Create a Python object from the Rust result and return it
-                    let py_result = delete_result_to_pydict(py, delete_result).unwrap();
-                    Ok(py_result.to_object(py))
-
-                    // Ok(Py::new(py, result)?.to_object(py))
-                }
-                Err(e) => {
-                    // Raise a Python exception on error
-                    Err(PyRuntimeError::new_err(format!("Delete one error: {}", e)))
-                }
+    pub fn delete_one(&self, py: Python<'_>, filter: Py<PyDict>) -> PyResult<Py<PyAny>> {
+        let bson_doc: Document = match convert_py_obj_to_document(filter.bind(py).as_any()) {
+            Ok(d) => d,
+            Err(e) => return Err(PyRuntimeError::new_err(format!("Delete one : {}", e))),
+        };
+        match self.inner.delete_one(bson_doc) {
+            Ok(delete_result) => {
+                let py_result = delete_result_to_pydict(py, delete_result)?;
+                Ok(py_result.into_any())
             }
-        })
+            Err(e) => Err(PyRuntimeError::new_err(format!("Delete one error: {}", e))),
+        }
     }
 
-    pub fn delete_many(&self, filter: Py<PyDict>) -> PyResult<PyObject> {
-        // Acquire the Python GIL (Global Interpreter Lock)
-        // let filter_doc = convert_py_obj_to_document(filter.to_object(py).as_any())?;
-        Python::with_gil(|py| {
-            let bson_doc: Document = match convert_py_obj_to_document(filter.to_object(py).as_any())
-            {
-                Ok(d) => d,
-                Err(e) => return Err(PyRuntimeError::new_err(format!("Delete many : {}", e))),
-            };
+    pub fn delete_many(&self, py: Python<'_>, filter: Py<PyDict>) -> PyResult<Py<PyAny>> {
+        let bson_doc: Document = match convert_py_obj_to_document(filter.bind(py).as_any()) {
+            Ok(d) => d,
+            Err(e) => return Err(PyRuntimeError::new_err(format!("Delete many : {}", e))),
+        };
 
-            match self.inner.delete_many(bson_doc) {
-                Ok(delete_result) => {
-                    // Create a Python object from the Rust result and return it
-                    let py_result = delete_result_to_pydict(py, delete_result).unwrap();
-                    Ok(py_result.to_object(py))
-
-                    // Ok(Py::new(py, result)?.to_object(py))
-                }
-                Err(e) => {
-                    // Raise a Python exception on error
-                    Err(PyRuntimeError::new_err(format!("Delete one error: {}", e)))
-                }
+        match self.inner.delete_many(bson_doc) {
+            Ok(delete_result) => {
+                let py_result = delete_result_to_pydict(py, delete_result)?;
+                Ok(py_result.into_any())
             }
-        })
+            Err(e) => Err(PyRuntimeError::new_err(format!("Delete one error: {}", e))),
+        }
     }
 
-    fn aggregate(&self, pipeline: Py<PyList>) -> PyResult<PyObject> {
-        Python::with_gil(|py: Python<'_>| {
-            // Now you can use `py` inside this block.
-            let pipeline_documents: Vec<Document> =
-                convert_py_list_to_vec_document(pipeline.to_object(py).as_any());
-            match self.inner.aggregate(pipeline_documents).run() {
-                Ok(agg_cursor) => {
-                    let vec_res: Vec<Py<PyDict>> = agg_cursor
-                        .map(|x| document_to_pydict(py, x.unwrap()).unwrap())
-                        .collect();
-                    Ok(vec_res.to_object(py))
-                }
-                Err(e) => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                    "Error in Aggregate {}",
-                    e
-                ))),
+    fn aggregate(&self, py: Python<'_>, pipeline: Py<PyList>) -> PyResult<Py<PyAny>> {
+        let pipeline_documents = convert_py_list_to_vec_document(pipeline.bind(py))?;
+        match self.inner.aggregate(pipeline_documents).run() {
+            Ok(agg_cursor) => {
+                let vec_res: Vec<Py<PyDict>> = agg_cursor
+                    .map(|x| document_to_pydict(py, x.unwrap()).unwrap())
+                    .collect();
+                vec_res.into_py_any(py)
             }
-        })
+            Err(e) => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                "Error in Aggregate {}",
+                e
+            ))),
+        }
     }
 
-    pub fn find_one(&self, py: Python, filter: Py<PyDict>) -> PyResult<Option<PyObject>> {
+    pub fn find_one(&self, py: Python<'_>, filter: Py<PyDict>) -> PyResult<Option<Py<PyAny>>> {
         // Convert PyDict to BSON Document
-        let filter_doc = convert_py_obj_to_document(filter.to_object(py).as_any())?;
+        let filter_doc = convert_py_obj_to_document(filter.bind(py).as_any())?;
         // Call the Rust method `find_one`
         match self.inner.find_one(filter_doc) {
             Ok(Some(result_doc)) => {
                 // Convert BSON Document to Python Dict
                 let py_result = document_to_pydict(py, result_doc).unwrap();
-                Ok(Some(py_result.to_object(py)))
+                Ok(Some(py_result.into_any()))
             }
             Ok(None) => Ok(None), // Return None if no document is found
             Err(err) => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
@@ -229,9 +172,9 @@ impl PyCollection {
             ))),
         }
     }
-    pub fn find(&self, py: Python, filter: Py<PyDict>) -> PyResult<Option<PyObject>> {
+    pub fn find(&self, py: Python<'_>, filter: Py<PyDict>) -> PyResult<Option<Py<PyAny>>> {
         // Convert PyDict to BSON Document
-        let filter_doc = convert_py_obj_to_document(filter.to_object(py).as_any())?;
+        let filter_doc = convert_py_obj_to_document(filter.bind(py).as_any())?;
 
         // Call the Rust method `find_one`
         match self.inner.find(filter_doc).run() {
@@ -241,7 +184,7 @@ impl PyCollection {
                     .map(|x| document_to_pydict(py, x.unwrap()).unwrap())
                     .collect();
                 // let py_result = document_to_pydict(py, result_doc).unwrap();
-                Ok(Some(py_result.to_object(py)))
+                Ok(Some(py_result.into_py_any(py)?))
             }
             // Ok(None) => Ok(None), // Return None if no document is found
             Err(err) => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(

--- a/py-polodb/tests/conftest.py
+++ b/py-polodb/tests/conftest.py
@@ -1,32 +1,19 @@
 import pytest
 from polodb import PoloDB
 
-import os
-import shutil
-
-from pathlib import Path
-
-BASE_DIR = Path(__file__).resolve().parent.parent
-
-
-TEST_DATA_DIR = BASE_DIR / "data"
-TEST_DATA_PATH = TEST_DATA_DIR / "dbtest"
 TEST_COLLECTION_NAME = "test_collection"
 
-os.path.exists(TEST_DATA_DIR.absolute()) or os.makedirs(TEST_DATA_DIR.absolute())
+
+@pytest.fixture
+def data_path(tmp_path):
+    return (tmp_path / "dbtest").as_posix()
 
 
-@pytest.fixture(scope="module")
-def data_path():
-    return TEST_DATA_PATH.as_posix()
-
-
-@pytest.fixture(scope="module")
+@pytest.fixture
 def collection_name():
     return TEST_COLLECTION_NAME
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def db(data_path):
-    yield PoloDB(data_path)
-    shutil.rmtree(data_path)
+    return PoloDB(data_path)

--- a/py-polodb/tests/test_database.py
+++ b/py-polodb/tests/test_database.py
@@ -1,3 +1,5 @@
+import pytest
+
 from polodb import PoloDB, Collection
 
 
@@ -10,6 +12,7 @@ def test_db_collection_creation(db, collection_name):
     collection = db.collection(collection_name)
     assert isinstance(collection, Collection)
     assert collection.name() == collection_name
+    assert db[collection_name].name() == collection_name
 
 
 def test_db_list_collection_names(db, collection_name):
@@ -18,12 +21,89 @@ def test_db_list_collection_names(db, collection_name):
     assert collection_name in collections
 
 
-def test_db_insert_and_find_one(db):
-    # Test inserting and finding a document
+def test_insert_one_round_trip_and_missing_result(db):
     collection = db.collection("test_collection")
-    entry = {"name": "Alice", "age": 30}
+    entry = {
+        "name": "Alice",
+        "active": True,
+        "age": 30,
+        "score": 9.5,
+        "profile": {"city": "Paris"},
+        "tags": ["admin", 7],
+    }
     insert_result = collection.insert_one(entry)
-    assert insert_result is not None
+    assert set(insert_result) == {"inserted_id"}
+
     found_entry = collection.find_one({"name": "Alice"})
-    assert found_entry["name"] == "Alice"
-    assert found_entry["age"] == 30
+    for key, value in entry.items():
+        assert found_entry[key] == value
+
+    assert collection.find_one({"name": "missing"}) is None
+
+
+def test_insert_many_find_and_count(db):
+    collection = db.collection("test_collection")
+    insert_result = collection.insert_many(
+        [
+            {"name": "Alice", "group": "staff"},
+            {"name": "Bob", "group": "staff"},
+            {"name": "Carol", "group": "guest"},
+        ]
+    )
+
+    assert set(insert_result) == {0, 1, 2}
+    assert collection.len() == 3
+    assert {item["name"] for item in collection.find({"group": "staff"})} == {
+        "Alice",
+        "Bob",
+    }
+
+
+def test_update_results_and_persisted_values(db):
+    collection = db.collection("test_collection")
+    collection.insert_many(
+        [
+            {"name": "Alice", "group": "staff", "active": False},
+            {"name": "Bob", "group": "staff", "active": False},
+            {"name": "Carol", "group": "guest", "active": False},
+        ]
+    )
+
+    update_one = collection.update_one(
+        {"name": "Alice"}, {"$set": {"active": True}}
+    )
+    assert update_one == {"matched_count": 1, "modified_count": 1}
+    assert collection.find_one({"name": "Alice"})["active"] is True
+
+    update_many = collection.update_many(
+        {"group": "staff"}, {"$set": {"role": "member"}}
+    )
+    assert update_many == {"matched_count": 2, "modified_count": 2}
+    assert len(collection.find({"role": "member"})) == 2
+
+
+def test_aggregate_and_delete_results(db):
+    collection = db.collection("test_collection")
+    collection.insert_many(
+        [
+            {"name": "banana", "color": "yellow"},
+            {"name": "pear", "color": "yellow"},
+            {"name": "apple", "color": "red"},
+        ]
+    )
+
+    aggregate_result = collection.aggregate(
+        [{"$match": {"color": "yellow"}}, {"$count": "count"}]
+    )
+    assert aggregate_result == [{"count": 2}]
+
+    assert collection.delete_one({"color": "yellow"}) == {"deleted_count": 1}
+    assert collection.delete_many({"color": "yellow"}) == {"deleted_count": 1}
+    assert collection.len() == 1
+
+
+def test_invalid_python_value_returns_exception(db):
+    collection = db.collection("test_collection")
+
+    with pytest.raises(RuntimeError, match="Unsupported Python type"):
+        collection.insert_one({"unsupported": object()})

--- a/src/librocksdb-sys/Cargo.toml
+++ b/src/librocksdb-sys/Cargo.toml
@@ -41,4 +41,3 @@ cc = { version = "1.0", features = ["parallel"] }
 bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
 glob = "0.3"
 pkg-config = { version = "0.3", optional = true }
-pyo3-build-config = "0.22.3"

--- a/src/librocksdb-sys/build.rs
+++ b/src/librocksdb-sys/build.rs
@@ -29,10 +29,6 @@ fn rocksdb_include_dir() -> String {
     }
 }
 
-fn bind_python() {
-    pyo3_build_config::add_extension_module_link_args();
-}
-
 fn bindgen_rocksdb() {
     let bindings = bindgen::Builder::default()
         .header(rocksdb_include_dir() + "/rocksdb/c.h")
@@ -363,7 +359,6 @@ fn main() {
         update_submodules();
     }
     bindgen_rocksdb();
-    bind_python();
     let target = env::var("TARGET").unwrap();
 
     if !try_to_find_and_link_lib("ROCKSDB") {


### PR DESCRIPTION
## What changed

- decouple the Rust core and RocksDB build from Python/PyO3
- migrate the Python extension to PyO3 0.29 and package it as `polodb.rust_polodb`
- build and install real wheels in CI for Python 3.12, 3.13, and 3.14
- continuously verify the Python binding's Rust 1.83 MSRV
- add a stable `Rust / Required CI Gate` check over Rust and Python jobs
- upgrade GitHub Actions and tighten workflow permissions
- make release builds reproducible with locked dependencies, exact tag-to-commit resolution, one publish job, and tag-scoped concurrency

## Root cause

`polodb-librocksdb-sys` had an unconditional `pyo3-build-config` build dependency and always emitted Python extension linker flags. That coupled every Rust workspace build to a local Python installation. The Python binding also used removed PyO3 APIs and its previous packaging configuration could pass tests from the source tree while producing an incomplete wheel.

## Impact

Rust-only builds no longer require Python. Python CI now validates the distributable wheel instead of an editable/source-tree import. Release artifacts are built from one verified tag commit and published by a single write-scoped job.

## Validation

- `cargo test --locked --release --verbose --workspace --exclude py-binding-polodb`
- `cargo +1.83.0 check --locked -p py-binding-polodb`
- actual wheel build/install and 8 pytest cases on local CPython 3.12 and 3.14
- wheel contents and PEP 621 metadata inspection
- Rust dependency-tree checks confirm core/RocksDB no longer depend on PyO3
- `actionlint`, YAML parsing, `git diff --check`, and `cargo metadata --locked`

Supersedes #209.
