### PR TITLE
Fix bundled RocksDB builds with mismatched x86 CPU features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,6 +54,28 @@ jobs:
       - name: Build Rust workspace
         run: cargo build --locked --release --workspace --exclude py-binding-polodb
 
+  rocksdb-x86-feature-compat:
+    name: RocksDB x86 Feature Compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-rocksdb-x86-feature-compat-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build RocksDB with AVX but without PCLMUL
+        env:
+          CXXFLAGS: -mavx -mno-pclmul
+        run: cargo build --locked --release --verbose -p polodb-librocksdb-sys
+
   python-bindings:
     name: Python Bindings (${{ matrix.python-version }})
     runs-on: ubuntu-latest
@@ -142,6 +164,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - rust-core
+      - rocksdb-x86-feature-compat
       - python-bindings
       - python-bindings-msrv
     runs-on: ubuntu-latest
@@ -149,11 +172,13 @@ jobs:
       - name: Verify required jobs succeeded
         env:
           RUST_CORE_RESULT: ${{ needs.rust-core.result }}
+          ROCKSDB_X86_FEATURE_COMPAT_RESULT: ${{ needs.rocksdb-x86-feature-compat.result }}
           PYTHON_BINDINGS_RESULT: ${{ needs.python-bindings.result }}
           PYTHON_BINDINGS_MSRV_RESULT: ${{ needs.python-bindings-msrv.result }}
         run: |
-          if [[ "$RUST_CORE_RESULT" != "success" || "$PYTHON_BINDINGS_RESULT" != "success" || "$PYTHON_BINDINGS_MSRV_RESULT" != "success" ]]; then
+          if [[ "$RUST_CORE_RESULT" != "success" || "$ROCKSDB_X86_FEATURE_COMPAT_RESULT" != "success" || "$PYTHON_BINDINGS_RESULT" != "success" || "$PYTHON_BINDINGS_MSRV_RESULT" != "success" ]]; then
             echo "Rust Core result: $RUST_CORE_RESULT"
+            echo "RocksDB x86 feature compatibility result: $ROCKSDB_X86_FEATURE_COMPAT_RESULT"
             echo "Python Bindings result: $PYTHON_BINDINGS_RESULT"
             echo "Python Bindings MSRV result: $PYTHON_BINDINGS_MSRV_RESULT"
             exit 1

--- a/src/librocksdb-sys/build.rs
+++ b/src/librocksdb-sys/build.rs
@@ -101,13 +101,11 @@ fn build_rocksdb() {
         .filter(|file| !matches!(*file, "util/build_version.cc"))
         .collect::<Vec<&'static str>>();
 
-    if let (true, Ok(target_feature_value)) = (
-        target.contains("x86_64"),
-        env::var("CARGO_CFG_TARGET_FEATURE"),
-    ) {
+    if target.contains("x86_64") {
         // This is needed to enable hardware CRC32C. Technically, SSE 4.2 is
         // only available since Intel Nehalem (about 2010) and AMD Bulldozer
         // (about 2011).
+        let target_feature_value = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
         let target_features: Vec<_> = target_feature_value.split(',').collect();
 
         if target_features.contains(&"sse2") {
@@ -132,6 +130,11 @@ fn build_rocksdb() {
         }
         if !target.contains("android") && target_features.contains(&"pclmulqdq") {
             config.flag_if_supported("-mpclmul");
+        } else {
+            // RocksDB 9 assumes AVX implies PCLMUL. That is not true for all
+            // x86-64 targets (or for custom CXXFLAGS), so explicitly disable
+            // its PCLMUL implementation unless Cargo enables the feature.
+            config.define("NO_PCLMUL", None);
         }
     }
 
@@ -265,6 +268,12 @@ fn build_rocksdb() {
     config.file("build_version.cc");
 
     config.cpp(true);
+    if !target.contains("windows") {
+        // Some RocksDB 9 headers use fixed-width integer types without
+        // including <cstdint> directly. Newer standard libraries no longer
+        // provide those declarations transitively in every translation unit.
+        config.flag("-include").flag("cstdint");
+    }
     config.flag_if_supported("-std=c++17");
     config.compile("librocksdb.a");
 }


### PR DESCRIPTION
## Summary

- disable RocksDB's PCLMUL implementation when Cargo does not enable `pclmulqdq`
- force-include `<cstdint>` for bundled RocksDB builds on non-Windows targets
- add an Ubuntu x86 regression job that builds with AVX enabled and PCLMUL disabled

## Root cause

Bundled RocksDB 9 assumes that AVX implies PCLMUL. Custom x86 toolchains or `CXXFLAGS` can enable AVX without enabling PCLMUL, so RocksDB selects `_mm_clmulepi64_si128` while the compiler rejects it because `-mpclmul` is absent. The build now uses RocksDB's `NO_PCLMUL` escape hatch unless Cargo explicitly enables `pclmulqdq`.

Some RocksDB 9 headers also rely on transitive declarations for fixed-width integer types. Force-including `<cstdint>` matches the current rust-rocksdb workaround and keeps newer C++ standard libraries building.

## Validation

- `cargo check --locked -p polodb-librocksdb-sys`
- `cargo test --locked -p polodb-librocksdb-sys` (11 unit tests and the FFI integration test passed)
- workflow YAML parse, `rustfmt --check src/librocksdb-sys/build.rs`, and `git diff --check`
- new CI regression build with `CXXFLAGS="-mavx -mno-pclmul"`

Fixes #203
