### PR TITLE
chore: prepare 5.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 
+# 5.2.0
+
+- Update Rust and Python dependencies, including security-related upgrades
+  - #212
+  - #226
+  - #228
+- Restore and strengthen CI coverage for Rust, Python bindings, MSRV, and release builds
+  - #225
+- Upgrade the Python bindings to PyO3 0.29 and validate installed wheels on Python 3.12 through 3.14
+  - #225
+- Harden bundled RocksDB builds for x86 CPU feature combinations and newer GCC toolchains
+  - #227
+
 # 5.1.4
 
 - Improve mongodb compatibility

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,7 +1680,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "polodb"
-version = "5.1.4"
+version = "5.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "polodb-librocksdb-sys"
-version = "9.0.0-alpha.1"
+version = "9.0.0-alpha.2"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "polodb_core"
-version = "5.1.4"
+version = "5.2.0"
 dependencies = [
  "bson 2.15.0",
  "byteorder",

--- a/src/librocksdb-sys/Cargo.toml
+++ b/src/librocksdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polodb-librocksdb-sys"
-version = "9.0.0-alpha.1"
+version = "9.0.0-alpha.2"
 edition = "2018"
 rust-version = "1.70.0"
 authors = ["Karl Hobley <karlhobley10@gmail.com>", "Arkadiy Paronyan <arkadiy@ethcore.io>", "Vincent Chan <okcdz@diverse.space>"]
@@ -8,6 +8,7 @@ license = "MIT/Apache-2.0/BSD-3-Clause"
 description = "Native bindings to librocksdb"
 readme = "README.md"
 repository = "https://github.com/rust-rocksdb/rust-rocksdb"
+exclude = ["rocksdb/docs/**", "rocksdb/java/**", "snappy/third_party/**"]
 keywords = [ "bindings", "ffi", "rocksdb" ]
 categories = [ "api-bindings", "database", "external-ffi-bindings" ]
 links = "rocksdb"

--- a/src/polodb/Cargo.toml
+++ b/src/polodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polodb"
-version = "5.1.4"
+version = "5.2.0"
 authors = ["Vincent Chan <okcdz@diverse.space>"]
 repository = "https://github.com/PoloDB/PoloDB"
 description = "The server of PoloDB, compatible with MongoDB"
@@ -20,7 +20,7 @@ zlib-compression = ["dep:flate2"]
 snappy-compression = ["dep:snap"]
 
 [dependencies]
-polodb_core = { path = "../polodb_core", version="5.1.4" }
+polodb_core = { path = "../polodb_core", version="5.2.0" }
 tokio = { version = "1.45.0", features = ["full"] }
 tokio-util = "0.7.15"
 clap = "4.5.15"

--- a/src/polodb_core/Cargo.toml
+++ b/src/polodb_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polodb_core"
-version = "5.1.4"
+version = "5.2.0"
 authors = ["Vincent Chan <okcdz@diverse.space>"]
 license = "Apache-2.0"
 edition = "2018"
@@ -28,7 +28,7 @@ uuid = { version = "1.10.0", features = [
 thiserror = "1.0.63"
 indexmap = { version = "2.4.0", features = ["serde"] }
 regex = "1.10"
-polodb-librocksdb-sys = { path = "../librocksdb-sys", version = "9.0.0-alpha.1", features = ["default", "mt_static"] }
+polodb-librocksdb-sys = { path = "../librocksdb-sys", version = "9.0.0-alpha.2", features = ["default", "mt_static"] }
 
 [dev-dependencies]
 polodb_line_diff = { path = "../polodb_line_diff" }


### PR DESCRIPTION
## Summary

Prepare PoloDB 5.2.0 for release.

- bump `polodb` and `polodb_core` to 5.2.0
- bump `polodb-librocksdb-sys` to 9.0.0-alpha.2
- keep internal dependency versions and `Cargo.lock` aligned
- add 5.2.0 release notes
- exclude unused RocksDB/Snappy docs and test assets from the sys crate package

## Validation

- `cargo test --locked --release --verbose --workspace --exclude py-binding-polodb`
- `cargo publish --dry-run --locked --allow-dirty -p polodb-librocksdb-sys`
- `cargo metadata --locked --format-version 1 --no-deps`
- package file-list checks for `polodb_core` and `polodb`

The sys crate archive is 5.8 MiB compressed and its exact packaged source compiles successfully.

## Publish order after merge

1. Tag the merged commit as `v5.2.0`
2. Publish `polodb-librocksdb-sys 9.0.0-alpha.2`
3. Publish `polodb_core 5.2.0`
4. Publish `polodb 5.2.0`
5. Trigger `release.yml` with `tag=v5.2.0`
