### PR TITLE
Fix MongoDB-compatible $in matching for stored arrays

### DIFF
--- a/src/polodb_core/tests/test_in.rs
+++ b/src/polodb_core/tests/test_in.rs
@@ -1,0 +1,461 @@
+// Copyright 2024 Vincent Chan
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bson::oid::ObjectId;
+use bson::{doc, Bson, Document, Regex};
+use polodb_core::{Collection, CollectionT};
+
+mod common;
+
+use common::prepare_db;
+
+fn matching_ids(collection: &Collection<Document>, filter: Document) -> Vec<String> {
+    let mut ids = collection
+        .find(filter)
+        .run()
+        .unwrap()
+        .map(|result| result.unwrap().get_str("_id").unwrap().to_owned())
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids
+}
+
+fn assert_matching_ids(collection: &Collection<Document>, filter: Document, expected: &[&str]) {
+    let mut expected = expected
+        .iter()
+        .map(|id| (*id).to_owned())
+        .collect::<Vec<_>>();
+    expected.sort();
+    assert_eq!(matching_ids(collection, filter), expected);
+}
+
+#[test]
+fn test_in_matches_scalars_and_equivalent_numeric_types() {
+    let db = prepare_db("test-in-scalars-and-numbers").unwrap();
+    let collection = db.collection::<Document>("items");
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "int32", "value": Bson::Int32(7) },
+            doc! { "_id": "int64", "value": Bson::Int64(7) },
+            doc! { "_id": "double", "value": Bson::Double(7.0) },
+            doc! { "_id": "negative_zero", "value": Bson::Double(-0.0) },
+            doc! { "_id": "large_exact", "value": Bson::Int64(9_007_199_254_740_992) },
+            doc! { "_id": "large_next", "value": Bson::Int64(9_007_199_254_740_993) },
+            doc! { "_id": "i64_min", "value": Bson::Int64(i64::MIN) },
+            doc! { "_id": "i64_max", "value": Bson::Int64(i64::MAX) },
+            doc! { "_id": "other", "value": 8 },
+            doc! { "_id": "string", "value": "seven" },
+            doc! { "_id": "symbol", "value": Bson::Symbol("seven".into()) },
+            doc! { "_id": "symbol_array", "value": [Bson::Symbol("seven".into())] },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$in": [Bson::Int64(7)] } },
+        &["double", "int32", "int64"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$in": ["seven", 8] } },
+        &["other", "string", "symbol", "symbol_array"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$in": [Bson::Symbol("seven".into())] } },
+        &["string", "symbol", "symbol_array"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$in": [0] } },
+        &["negative_zero"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$in": [Bson::Double(9_007_199_254_740_992.0)] } },
+        &["large_exact"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$in": [Bson::Double(9_223_372_036_854_775_808.0)] } },
+        &[],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$in": [Bson::Double(-9_223_372_036_854_775_808.0)] } },
+        &["i64_min"],
+    );
+}
+
+#[test]
+fn test_in_matches_array_elements_exact_arrays_and_nested_arrays() {
+    let db = prepare_db("test-in-array-semantics").unwrap();
+    let collection = db.collection::<Document>("items");
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "scalar", "value": 2 },
+            doc! { "_id": "array", "value": [1, 2] },
+            doc! { "_id": "reordered", "value": [2, 1] },
+            doc! { "_id": "nested", "value": [[1, 2], 3] },
+            doc! { "_id": "empty", "value": [] },
+            doc! { "_id": "nested_empty", "value": [[]] },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$in": [2] } },
+        &["array", "reordered", "scalar"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! {
+            "value": {
+                "$in": [Bson::Array(vec![Bson::Int32(1), Bson::Int32(2)])]
+            }
+        },
+        &["array", "nested"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$in": [Bson::Array(Vec::new())] } },
+        &["empty", "nested_empty"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$nin": [2] } },
+        &["empty", "nested", "nested_empty"],
+    );
+}
+
+#[test]
+fn test_in_document_equality_is_recursive_and_order_sensitive() {
+    let db = prepare_db("test-in-document-equality").unwrap();
+    let collection = db.collection::<Document>("items");
+
+    let ordered = doc! { "a": 1, "b": 2 };
+    let reversed = doc! { "b": 2, "a": 1 };
+    let db_ref = doc! { "$ref": "targets", "$id": ObjectId::new() };
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "ordered", "value": ordered.clone() },
+            doc! { "_id": "reversed", "value": reversed.clone() },
+            doc! { "_id": "array_ordered", "value": [ordered.clone()] },
+            doc! { "_id": "different", "value": { "a": 1, "b": 3 } },
+            doc! { "_id": "db_ref", "value": db_ref.clone() },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$in": [Bson::Document(ordered)] } },
+        &["array_ordered", "ordered"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$in": [Bson::Document(reversed)] } },
+        &["reversed"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$in": [Bson::Document(db_ref)] } },
+        &["db_ref"],
+    );
+}
+
+#[test]
+fn test_in_regex_matches_only_strings_in_scalars_and_arrays() {
+    let db = prepare_db("test-in-regex").unwrap();
+    let collection = db.collection::<Document>("items");
+
+    let alice_regex = Regex {
+        pattern: "^ali".into(),
+        options: "i".into(),
+    };
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "scalar", "value": "Alice" },
+            doc! { "_id": "array", "value": ["Bob", "Carol"] },
+            doc! { "_id": "symbol", "value": Bson::Symbol("ALICE".into()) },
+            doc! { "_id": "symbol_array", "value": [Bson::Symbol("Alice".into())] },
+            doc! { "_id": "stored_regex", "value": Bson::RegularExpression(alice_regex.clone()) },
+            doc! { "_id": "regex_array", "value": [Bson::RegularExpression(alice_regex.clone())] },
+            doc! { "_id": "number", "value": 123 },
+            doc! { "_id": "other", "value": "David" },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! {
+            "value": {
+                "$in": [Bson::RegularExpression(alice_regex)]
+            }
+        },
+        &[
+            "regex_array",
+            "scalar",
+            "stored_regex",
+            "symbol",
+            "symbol_array",
+        ],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! {
+            "value": {
+                "$in": [Bson::RegularExpression(Regex {
+                    pattern: "^Car".into(),
+                    options: "".into(),
+                })]
+            }
+        },
+        &["array"],
+    );
+
+    assert!(collection
+        .find(doc! {
+            "value": {
+                "$in": [Bson::RegularExpression(Regex {
+                    pattern: "[".into(),
+                    options: "".into(),
+                })]
+            }
+        })
+        .run()
+        .is_err());
+    assert!(collection
+        .find(doc! {
+            "value": {
+                "$in": ["Alice", Bson::RegularExpression(Regex {
+                    pattern: "[".into(),
+                    options: "".into(),
+                })]
+            }
+        })
+        .run()
+        .is_err());
+
+    db.create_collection("empty").unwrap();
+    let empty_collection = db.collection::<Document>("empty");
+    assert!(empty_collection
+        .find(doc! {
+            "value": {
+                "$in": [Bson::RegularExpression(Regex {
+                    pattern: "[".into(),
+                    options: "".into(),
+                })]
+            }
+        })
+        .run()
+        .is_err());
+}
+
+#[test]
+fn test_in_and_nin_empty_candidate_arrays() {
+    let db = prepare_db("test-in-empty-candidates").unwrap();
+    let collection = db.collection::<Document>("items");
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "scalar", "value": 1 },
+            doc! { "_id": "array", "value": [1, 2] },
+            doc! { "_id": "null", "value": Bson::Null },
+            doc! { "_id": "missing" },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$in": Bson::Array(Vec::new()) } },
+        &[],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$nin": Bson::Array(Vec::new()) } },
+        &["array", "missing", "null", "scalar"],
+    );
+}
+
+#[test]
+fn test_in_nin_and_not_handle_null_and_missing_fields() {
+    let db = prepare_db("test-in-null-and-missing").unwrap();
+    let collection = db.collection::<Document>("items");
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "null", "value": Bson::Null },
+            doc! { "_id": "missing" },
+            doc! { "_id": "one", "value": 1 },
+            doc! { "_id": "two", "value": 2 },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$in": [Bson::Null] } },
+        &["missing", "null"],
+    );
+    assert_matching_ids(&collection, doc! { "value": { "$in": [1] } }, &["one"]);
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$nin": [1] } },
+        &["missing", "null", "two"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$nin": [Bson::Null] } },
+        &["one", "two"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$not": { "$in": [1] } } },
+        &["missing", "null", "two"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$not": { "$in": [Bson::Null] } } },
+        &["one", "two"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$not": { "$nin": [1] } } },
+        &["one"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$not": { "$nin": [Bson::Null] } } },
+        &["missing", "null"],
+    );
+}
+
+#[test]
+fn test_in_handles_missing_dotted_paths() {
+    let db = prepare_db("test-in-dotted-paths").unwrap();
+    let collection = db.collection::<Document>("items");
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "ada", "profile": { "name": "Ada" } },
+            doc! { "_id": "grace", "profile": { "name": "Grace" } },
+            doc! { "_id": "leaf_missing", "profile": {} },
+            doc! { "_id": "middle_missing" },
+            doc! { "_id": "middle_scalar", "profile": "legacy" },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! { "profile.name": { "$in": ["Ada"] } },
+        &["ada"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "profile.name": { "$in": [Bson::Null] } },
+        &["leaf_missing", "middle_missing", "middle_scalar"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "profile.name": { "$nin": ["Ada"] } },
+        &["grace", "leaf_missing", "middle_missing", "middle_scalar"],
+    );
+}
+
+#[test]
+fn test_in_negation_composes_with_other_predicates() {
+    let db = prepare_db("test-in-negation-composition").unwrap();
+    let collection = db.collection::<Document>("items");
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "included_missing", "kind": "included" },
+            doc! { "_id": "included_one", "kind": "included", "value": 1 },
+            doc! { "_id": "included_two", "kind": "included", "value": 2 },
+            doc! { "_id": "excluded_two", "kind": "excluded", "value": 2 },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! { "kind": "included", "value": { "$nin": [1] } },
+        &["included_missing", "included_two"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "kind": "included", "value": { "$not": { "$in": [1] } } },
+        &["included_missing", "included_two"],
+    );
+}
+
+#[test]
+fn test_in_and_nin_validate_operands_and_operator_documents() {
+    let db = prepare_db("test-in-invalid-operands").unwrap();
+    let collection = db.collection::<Document>("items");
+    collection
+        .insert_one(doc! { "_id": "one", "value": "Alice" })
+        .unwrap();
+
+    assert!(collection
+        .find(doc! { "value": { "$in": "Alice" } })
+        .run()
+        .is_err());
+    assert!(collection
+        .find(doc! { "value": { "$nin": 1 } })
+        .run()
+        .is_err());
+    assert!(collection
+        .find(doc! {
+            "value": {
+                "$in": [Bson::Document(doc! { "$regex": "^Ali" })]
+            }
+        })
+        .run()
+        .is_err());
+    assert!(collection
+        .find(doc! {
+            "value": {
+                "$in": [Bson::Document(doc! { "$gt": 1 })]
+            }
+        })
+        .run()
+        .is_err());
+    assert!(collection
+        .find(doc! {
+            "value": {
+                "$in": [Bson::Document(doc! { "$ref": "targets" })]
+            }
+        })
+        .run()
+        .is_err());
+
+    collection
+        .insert_one(doc! {
+            "_id": "literal",
+            "value": Bson::Document(doc! { "x": 1, "$regex": "literal" }),
+        })
+        .unwrap();
+    assert_matching_ids(
+        &collection,
+        doc! {
+            "value": {
+                "$in": [Bson::Document(doc! { "x": 1, "$regex": "literal" })]
+            }
+        },
+        &["literal"],
+    );
+}

--- a/src/polodb_core/vm/codegen.rs
+++ b/src/polodb_core/vm/codegen.rs
@@ -12,21 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use super::label::{JumpTableRecord, Label, LabelSlot};
 use crate::coll::collection_info::CollectionSpecification;
-use crate::errors::{mk_invalid_query_field};
+use crate::errors::mk_invalid_query_field;
 use crate::index::INDEX_PREFIX;
-use crate::vm::op::DbOp;
-use crate::vm::subprogram::SubProgramIndexItem;
-use crate::vm::SubProgram;
-use crate::{Error, Result};
-use bson::spec::{BinarySubtype, ElementType};
-use bson::{Array, Binary, Bson, Document};
 use crate::vm::aggregation_codegen_context::{AggregationCodeGenContext, PipelineItem};
 use crate::vm::global_variable::{GlobalVariable, GlobalVariableSlot};
+use crate::vm::op::DbOp;
 use crate::vm::operators::OpRegistry;
-use crate::vm::update_operators::{IncOperator, MaxOperator, MinOperator, MulOperator, PopOperator, PushOperator, RenameOperator, SetOperator, UnsetOperator, UpdateOperator};
+use crate::vm::query_matcher::validate_in_candidates;
+use crate::vm::subprogram::SubProgramIndexItem;
+use crate::vm::update_operators::{
+    IncOperator, MaxOperator, MinOperator, MulOperator, PopOperator, PushOperator, RenameOperator,
+    SetOperator, UnsetOperator, UpdateOperator,
+};
 use crate::vm::vm_add_fields::VmFuncAddFields;
 use crate::vm::vm_count::VmFuncCount;
 use crate::vm::vm_external_func::VmExternalFunc;
@@ -35,6 +34,10 @@ use crate::vm::vm_limit::VmFuncLimit;
 use crate::vm::vm_skip::VmFuncSkip;
 use crate::vm::vm_sort::VmFuncSort;
 use crate::vm::vm_unset::VmFuncUnset;
+use crate::vm::SubProgram;
+use crate::{Error, Result};
+use bson::spec::{BinarySubtype, ElementType};
+use bson::{Array, Binary, Bson, Document};
 
 const JUMP_TABLE_DEFAULT_SIZE: usize = 8;
 const PATH_DEFAULT_SIZE: usize = 8;
@@ -83,11 +86,19 @@ impl Codegen {
 
     #[inline]
     #[allow(dead_code)]
-    pub(super) fn new_global_variable_with_name(&mut self, name: String, init_value: Bson) -> Result<GlobalVariable> {
+    pub(super) fn new_global_variable_with_name(
+        &mut self,
+        name: String,
+        init_value: Bson,
+    ) -> Result<GlobalVariable> {
         self.new_global_variable_impl(init_value, Some(name.into_boxed_str()))
     }
 
-    fn new_global_variable_impl(&mut self, init_value: Bson, name: Option<Box<str>>) -> Result<GlobalVariable> {
+    fn new_global_variable_impl(
+        &mut self,
+        init_value: Bson,
+        name: Option<Box<str>>,
+    ) -> Result<GlobalVariable> {
         let id = self.program.global_variables.len() as u32;
         self.program.global_variables.push(GlobalVariableSlot {
             pos: 0,
@@ -424,16 +435,11 @@ impl Codegen {
         if query_doc.is_empty() {
             self.emit(DbOp::StoreR0_2);
             self.emit_u8(1);
-            return Ok(())
+            return Ok(());
         }
         for (key, value) in query_doc.iter() {
             crate::path_hint!(self, key.clone(), {
-                self.emit_query_tuple(
-                    key,
-                    value,
-                    result_label,
-                    not_found_label,
-                )?;
+                self.emit_query_tuple(key, value, result_label, not_found_label)?;
             });
         }
 
@@ -466,23 +472,14 @@ impl Codegen {
             let path_msg = format!("[{}]", index);
             crate::path_hint!(self, path_msg, {
                 let item_doc = crate::try_unwrap_document!("$and", item_doc_value);
-                self.emit_standard_query_doc(
-                    item_doc,
-                    result_label,
-
-                    not_found_label,
-                )?;
+                self.emit_standard_query_doc(item_doc, result_label, not_found_label)?;
             });
         }
 
         Ok(())
     }
 
-    fn emit_logic_or(
-        &mut self,
-        arr: &Array,
-        ret_label: Label,
-    ) -> Result<()> {
+    fn emit_logic_or(&mut self, arr: &Array, ret_label: Label) -> Result<()> {
         let cmp_label = self.new_label();
         self.emit_goto(DbOp::Goto, cmp_label);
 
@@ -496,11 +493,7 @@ impl Codegen {
                 let ret_label = self.new_label();
 
                 self.emit_label(query_label);
-                self.emit_standard_query_doc(
-                    item_doc,
-                    ret_label,
-                    ret_label
-                )?;
+                self.emit_standard_query_doc(item_doc, ret_label, ret_label)?;
 
                 self.emit_label(ret_label);
                 self.emit_ret(0);
@@ -532,19 +525,12 @@ impl Codegen {
             match key {
                 "$and" => {
                     let sub_arr = crate::try_unwrap_array!("$and", value);
-                    self.emit_logic_and(
-                        sub_arr.as_ref(),
-                        result_label,
-                        not_found_label,
-                    )?;
+                    self.emit_logic_and(sub_arr.as_ref(), result_label, not_found_label)?;
                 }
 
                 "$or" => {
                     let sub_arr = crate::try_unwrap_array!("$or", value);
-                    self.emit_logic_or(
-                        sub_arr.as_ref(),
-                        not_found_label,
-                    )?;
+                    self.emit_logic_or(sub_arr.as_ref(), not_found_label)?;
                 }
 
                 _ => {
@@ -557,12 +543,7 @@ impl Codegen {
         } else {
             match value {
                 Bson::Document(doc) => {
-                    return self.emit_query_tuple_document(
-                        key,
-                        doc,
-                        false,
-                        not_found_label,
-                    );
+                    return self.emit_query_tuple_document(key, doc, false, not_found_label);
                 }
 
                 Bson::Array(_) => {
@@ -601,11 +582,50 @@ impl Codegen {
         slices.len()
     }
 
+    fn get_field_or_null(&mut self, key: &str) -> usize {
+        let key_static_id = self.push_static(key.into());
+        self.emit(DbOp::GetFieldOrNull);
+        self.emit_u32(key_static_id);
+        1
+    }
+
     fn emit_logical(&mut self, op: DbOp, is_in_not: bool) {
         self.emit(op);
         if is_in_not {
             self.emit(DbOp::Not);
         }
+    }
+
+    fn validate_in_operand<'a>(&self, value: &'a Bson) -> Result<&'a Array> {
+        let values = match value {
+            Bson::Array(values) => values,
+            _ => {
+                return Err(Error::InvalidField(mk_invalid_query_field(
+                    self.last_key().into(),
+                    self.gen_path(),
+                )))
+            }
+        };
+
+        if values.iter().any(|value| {
+            matches!(
+                value,
+                Bson::Document(document)
+                    if document
+                        .keys()
+                        .next()
+                        .is_some_and(|key| key.starts_with('$'))
+                        && !(document.contains_key("$ref") && document.contains_key("$id"))
+            )
+        }) {
+            return Err(Error::InvalidField(mk_invalid_query_field(
+                self.last_key().into(),
+                self.gen_path(),
+            )));
+        }
+
+        validate_in_candidates(values)?;
+        Ok(values)
     }
 
     fn emit_query_tuple_document_kv(
@@ -659,17 +679,9 @@ impl Codegen {
 
             // check the value is array
             "$in" => {
-                match sub_value {
-                    Bson::Array(_) => (),
-                    _ => {
-                        return Err(Error::InvalidField(mk_invalid_query_field(
-                            self.last_key().into(),
-                            self.gen_path(),
-                        )))
-                    }
-                }
+                self.validate_in_operand(sub_value)?;
 
-                let field_size = self.recursively_get_field(key, not_found_label);
+                let field_size = self.get_field_or_null(key);
 
                 let stat_val_id = self.push_static(sub_value.clone());
                 self.emit_push_value(stat_val_id);
@@ -723,23 +735,15 @@ impl Codegen {
             }
 
             "$nin" => {
-                match sub_value {
-                    Bson::Array(_) => (),
-                    _ => {
-                        return Err(Error::InvalidField(mk_invalid_query_field(
-                            self.last_key().into(),
-                            self.gen_path(),
-                        )))
-                    }
-                }
+                self.validate_in_operand(sub_value)?;
 
-                let field_size = self.recursively_get_field(key, not_found_label);
+                let field_size = self.get_field_or_null(key);
 
                 let stat_val_id = self.push_static(sub_value.clone());
                 self.emit_push_value(stat_val_id);
-                self.emit_logical(DbOp::In, is_in_not);
+                self.emit_logical(DbOp::In, !is_in_not);
 
-                self.emit_goto(DbOp::IfTrue, not_found_label);
+                self.emit_goto(DbOp::IfFalse, not_found_label);
 
                 self.emit(DbOp::Pop2);
                 self.emit_u32((field_size + 1) as u32);
@@ -846,7 +850,11 @@ impl Codegen {
     // There are two stage of compiling pipeline
     // 1. Generate the layout code of the pipeline
     // 2. Generate the implementation code of the pipeline
-    pub fn emit_aggregation_pipeline(&mut self, ctx: &mut AggregationCodeGenContext, pipeline: &[Document]) -> Result<()> {
+    pub fn emit_aggregation_pipeline(
+        &mut self,
+        ctx: &mut AggregationCodeGenContext,
+        pipeline: &[Document],
+    ) -> Result<()> {
         if pipeline.is_empty() {
             self.emit(DbOp::ResultRow);
             self.emit(DbOp::Pop);
@@ -917,36 +925,39 @@ impl Codegen {
                         let count_name = match value {
                             Bson::String(s) => s,
                             _ => {
-                                return Err(Error::InvalidAggregationStage(Box::new(stage.clone())));
+                                return Err(Error::InvalidAggregationStage(Box::new(
+                                    stage.clone(),
+                                )));
                             }
                         };
 
                         let next_fun = ctx.items[index + 1].next_label;
-                        let external_func: Box<dyn VmExternalFunc> = Box::new(VmFuncCount::new(count_name.clone()));
+                        let external_func: Box<dyn VmExternalFunc> =
+                            Box::new(VmFuncCount::new(count_name.clone()));
                         self.emit_external_func(external_func, stage_ctx_item, next_fun);
                     }
                     "$group" => {
                         let next_fun = ctx.items[index + 1].next_label;
-                        let external_func: Box<dyn VmExternalFunc> = VmFuncGroup::compile(
-                            &mut self.paths,
-                            self.op_registry.clone(),
-                            value,
-                        )?;
+                        let external_func: Box<dyn VmExternalFunc> =
+                            VmFuncGroup::compile(&mut self.paths, self.op_registry.clone(), value)?;
                         self.emit_external_func(external_func, stage_ctx_item, next_fun);
                     }
                     "$skip" => {
                         let next_fun = ctx.items[index + 1].next_label;
-                        let external_func: Box<dyn VmExternalFunc> = VmFuncSkip::compile(&mut self.paths, value)?;
+                        let external_func: Box<dyn VmExternalFunc> =
+                            VmFuncSkip::compile(&mut self.paths, value)?;
                         self.emit_external_func(external_func, stage_ctx_item, next_fun);
                     }
                     "$limit" => {
                         let next_fun = ctx.items[index + 1].next_label;
-                        let external_func: Box<dyn VmExternalFunc> = VmFuncLimit::compile(&mut self.paths, value)?;
+                        let external_func: Box<dyn VmExternalFunc> =
+                            VmFuncLimit::compile(&mut self.paths, value)?;
                         self.emit_external_func(external_func, stage_ctx_item, next_fun);
                     }
                     "$sort" => {
                         let next_fun = ctx.items[index + 1].next_label;
-                        let external_func: Box<dyn VmExternalFunc> = VmFuncSort::compile(&mut self.paths, value)?;
+                        let external_func: Box<dyn VmExternalFunc> =
+                            VmFuncSort::compile(&mut self.paths, value)?;
                         self.emit_external_func(external_func, stage_ctx_item, next_fun);
                     }
                     "$addFields" => {
@@ -960,7 +971,8 @@ impl Codegen {
                     }
                     "$unset" => {
                         let next_fun = ctx.items[index + 1].next_label;
-                        let external_func: Box<dyn VmExternalFunc> = VmFuncUnset::compile(&mut self.paths, value)?;
+                        let external_func: Box<dyn VmExternalFunc> =
+                            VmFuncUnset::compile(&mut self.paths, value)?;
                         self.emit_external_func(external_func, stage_ctx_item, next_fun);
                     }
                     _ => {
@@ -973,7 +985,12 @@ impl Codegen {
         Ok(())
     }
 
-    fn emit_external_func(&mut self, external_func: Box<dyn VmExternalFunc>, stage_ctx_item: &PipelineItem, next_fun: Label) {
+    fn emit_external_func(
+        &mut self,
+        external_func: Box<dyn VmExternalFunc>,
+        stage_ctx_item: &PipelineItem,
+        next_fun: Label,
+    ) {
         let external_func_id = self.push_external_func(external_func);
         let go_next = self.new_label();
         let loop_next = self.new_label();
@@ -1008,7 +1025,11 @@ impl Codegen {
         self.emit_u32(param_size as u32);
     }
 
-    pub fn emit_aggregation_before_query(&mut self, ctx: &mut AggregationCodeGenContext, pipeline: &[Document]) -> Result<()> {
+    pub fn emit_aggregation_before_query(
+        &mut self,
+        ctx: &mut AggregationCodeGenContext,
+        pipeline: &[Document],
+    ) -> Result<()> {
         for stage_doc in pipeline {
             if stage_doc.is_empty() {
                 return Ok(());
@@ -1016,9 +1037,7 @@ impl Codegen {
 
             let label = self.new_label();
 
-            ctx.items.push(PipelineItem {
-                next_label: label,
-            });
+            ctx.items.push(PipelineItem { next_label: label });
         }
         Ok(())
     }

--- a/src/polodb_core/vm/mod.rs
+++ b/src/polodb_core/vm/mod.rs
@@ -12,23 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod op;
-mod subprogram;
-mod codegen;
-mod label;
-mod vm;
-mod global_variable;
 mod aggregation_codegen_context;
-mod vm_external_func;
-mod vm_count;
-mod vm_group;
+mod codegen;
+mod global_variable;
+mod label;
+mod op;
 mod operators;
+mod query_matcher;
+mod subprogram;
+mod update_operators;
+mod vm;
+mod vm_add_fields;
+mod vm_count;
+mod vm_external_func;
+mod vm_group;
+mod vm_limit;
 mod vm_skip;
 mod vm_sort;
-mod vm_limit;
 mod vm_unset;
-mod vm_add_fields;
-mod update_operators;
 
 pub(crate) use subprogram::SubProgram;
-pub(crate) use vm::{VM, VmState};
+pub(crate) use vm::{VmState, VM};

--- a/src/polodb_core/vm/op.rs
+++ b/src/polodb_core/vm/op.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp::Ordering;
 use bson::Bson;
+use std::cmp::Ordering;
 
 #[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -136,6 +136,13 @@ pub enum DbOp {
     // op1. value_index: 4bytes
     // op2. location: 4bytes
     GetField,
+
+    // get a dotted field path from the document on top of the stack
+    // push null when the field is missing
+    //
+    // 5 bytes
+    // op1. value_index: 4bytes
+    GetFieldOrNull,
 
     // remove the field
     //
@@ -300,7 +307,6 @@ pub enum DbOp {
     // Exit
     // Close cursor automatically
     Halt,
-
 }
 
 pub(crate) fn generic_cmp(op: DbOp, val1: &Bson, val2: &Bson) -> crate::Result<bool> {

--- a/src/polodb_core/vm/query_matcher.rs
+++ b/src/polodb_core/vm/query_matcher.rs
@@ -1,0 +1,324 @@
+// Copyright 2024 Vincent Chan
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bson::{Bson, Document, Regex};
+use regex::{Regex as CompiledRegex, RegexBuilder};
+
+use crate::errors::RegexError;
+use crate::{Error, Result};
+
+pub(super) fn field_path_value(document: &Document, path: &str) -> Option<Bson> {
+    let mut segments = path.split('.');
+    let first = segments.next()?;
+    let mut value = document.get(first)?;
+
+    for segment in segments {
+        value = value.as_document()?.get(segment)?;
+    }
+
+    Some(value.clone())
+}
+
+pub(super) fn matches_in(field_value: &Bson, candidates: &[Bson]) -> Result<bool> {
+    let compiled_regexes = compile_in_regexes(candidates)?;
+
+    for (candidate, compiled_regex) in candidates.iter().zip(compiled_regexes.iter()) {
+        if query_values_equal(field_value, candidate) {
+            return Ok(true);
+        }
+
+        if let Bson::Array(values) = field_value {
+            if values
+                .iter()
+                .any(|value| query_values_equal(value, candidate))
+            {
+                return Ok(true);
+            }
+        }
+
+        if compiled_regex
+            .as_ref()
+            .is_some_and(|regex| matches_compiled_regex(field_value, regex))
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+pub(super) fn validate_in_candidates(candidates: &[Bson]) -> Result<()> {
+    compile_in_regexes(candidates).map(|_| ())
+}
+
+pub(super) fn matches_regex(field_value: &Bson, expression: &Regex) -> Result<bool> {
+    let regex = compile_regex(expression)?;
+    Ok(regex.is_match(&field_value.to_string()))
+}
+
+fn matches_compiled_regex(field_value: &Bson, regex: &CompiledRegex) -> bool {
+    match field_value {
+        Bson::String(value) | Bson::Symbol(value) => regex.is_match(value),
+        Bson::Array(values) => values.iter().any(|value| match value {
+            Bson::String(value) | Bson::Symbol(value) => regex.is_match(value),
+            _ => false,
+        }),
+        _ => false,
+    }
+}
+
+fn compile_in_regexes(candidates: &[Bson]) -> Result<Vec<Option<CompiledRegex>>> {
+    candidates
+        .iter()
+        .map(|candidate| match candidate {
+            Bson::RegularExpression(expression) => compile_regex(expression).map(Some),
+            _ => Ok(None),
+        })
+        .collect()
+}
+
+fn compile_regex(expression: &Regex) -> Result<CompiledRegex> {
+    let mut builder = RegexBuilder::new(expression.pattern.as_str());
+
+    for option in expression.options.chars() {
+        match option {
+            'i' => builder.case_insensitive(true),
+            'm' => builder.multi_line(true),
+            's' => builder.dot_matches_new_line(true),
+            'u' => builder.unicode(true),
+            'U' => builder.swap_greed(true),
+            'x' => builder.ignore_whitespace(true),
+            _ => {
+                return Err(Error::from(RegexError {
+                    error: format!("unknown regex option: {option}"),
+                    expression: expression.pattern.clone(),
+                    options: expression.options.clone(),
+                }));
+            }
+        };
+    }
+
+    builder.build().map_err(|error| {
+        Error::from(RegexError {
+            error: format!("regex build error: {error}"),
+            expression: expression.pattern.clone(),
+            options: expression.options.clone(),
+        })
+    })
+}
+
+fn query_values_equal(left: &Bson, right: &Bson) -> bool {
+    match (left, right) {
+        (
+            Bson::Int32(_) | Bson::Int64(_) | Bson::Double(_),
+            Bson::Int32(_) | Bson::Int64(_) | Bson::Double(_),
+        ) => numeric_values_equal(left, right),
+        (Bson::Array(left), Bson::Array(right)) => {
+            left.len() == right.len()
+                && left
+                    .iter()
+                    .zip(right.iter())
+                    .all(|(left, right)| query_values_equal(left, right))
+        }
+        (Bson::Document(left), Bson::Document(right)) => documents_equal(left, right),
+        (Bson::JavaScriptCodeWithScope(left), Bson::JavaScriptCodeWithScope(right)) => {
+            left.code == right.code && documents_equal(&left.scope, &right.scope)
+        }
+        (Bson::Binary(left), Bson::Binary(right)) => {
+            left.subtype == right.subtype && left.bytes == right.bytes
+        }
+        (Bson::String(left), Bson::Symbol(right)) | (Bson::Symbol(left), Bson::String(right)) => {
+            left == right
+        }
+        _ => left == right,
+    }
+}
+
+fn numeric_values_equal(left: &Bson, right: &Bson) -> bool {
+    match (left, right) {
+        (Bson::Double(left), Bson::Double(right)) => {
+            left == right || (left.is_nan() && right.is_nan())
+        }
+        (Bson::Double(double), Bson::Int32(integer))
+        | (Bson::Int32(integer), Bson::Double(double)) => {
+            integer_equals_double(i64::from(*integer), *double)
+        }
+        (Bson::Double(double), Bson::Int64(integer))
+        | (Bson::Int64(integer), Bson::Double(double)) => integer_equals_double(*integer, *double),
+        (Bson::Int32(left), Bson::Int32(right)) => left == right,
+        (Bson::Int32(left), Bson::Int64(right)) => i64::from(*left) == *right,
+        (Bson::Int64(left), Bson::Int32(right)) => *left == i64::from(*right),
+        (Bson::Int64(left), Bson::Int64(right)) => left == right,
+        _ => false,
+    }
+}
+
+fn integer_equals_double(integer: i64, double: f64) -> bool {
+    const I64_LOWER_BOUND: f64 = -9_223_372_036_854_775_808.0;
+    const I64_UPPER_BOUND: f64 = 9_223_372_036_854_775_808.0;
+
+    double.is_finite()
+        && double.trunc() == double
+        && (I64_LOWER_BOUND..I64_UPPER_BOUND).contains(&double)
+        && double as i64 == integer
+}
+
+fn documents_equal(left: &Document, right: &Document) -> bool {
+    left.len() == right.len()
+        && left.iter().zip(right.iter()).all(
+            |((left_key, left_value), (right_key, right_value))| {
+                left_key == right_key && query_values_equal(left_value, right_value)
+            },
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use bson::spec::BinarySubtype;
+    use bson::{doc, Binary, Bson, JavaScriptCodeWithScope, Regex};
+
+    use super::{field_path_value, matches_in, query_values_equal};
+
+    #[test]
+    fn field_path_lookup_preserves_terminal_documents() {
+        let document = doc! {
+            "profile": {
+                "name": "Ada",
+            },
+        };
+
+        assert_eq!(
+            field_path_value(&document, "profile"),
+            document.get("profile").cloned(),
+        );
+        assert_eq!(
+            field_path_value(&document, "profile.name"),
+            Some(Bson::String("Ada".into())),
+        );
+    }
+
+    #[test]
+    fn query_equality_is_recursive_and_ordered() {
+        assert!(query_values_equal(
+            &Bson::Array(vec![Bson::Int32(1)]),
+            &Bson::Array(vec![Bson::Int64(1)]),
+        ));
+
+        assert!(!query_values_equal(
+            &Bson::Document(doc! { "a": 1, "b": 2 }),
+            &Bson::Document(doc! { "b": 2, "a": 1 }),
+        ));
+    }
+
+    #[test]
+    fn numeric_equality_is_exact_across_bson_types() {
+        assert!(query_values_equal(&Bson::Double(-0.0), &Bson::Int32(0)));
+        assert!(query_values_equal(&Bson::Double(0.0), &Bson::Double(-0.0)));
+        assert!(query_values_equal(
+            &Bson::Double(f64::NAN),
+            &Bson::Double(f64::NAN),
+        ));
+        assert!(!query_values_equal(
+            &Bson::Int64(9_007_199_254_740_993),
+            &Bson::Double(9_007_199_254_740_992.0),
+        ));
+        assert!(!query_values_equal(
+            &Bson::Int64(i64::MAX),
+            &Bson::Double(9_223_372_036_854_775_808.0),
+        ));
+        assert!(query_values_equal(
+            &Bson::Int64(i64::MIN),
+            &Bson::Double(-9_223_372_036_854_775_808.0),
+        ));
+    }
+
+    #[test]
+    fn binary_equality_includes_subtype() {
+        let bytes = vec![1, 2, 3];
+        assert!(!query_values_equal(
+            &Bson::Binary(Binary {
+                subtype: BinarySubtype::Generic,
+                bytes: bytes.clone(),
+            }),
+            &Bson::Binary(Binary {
+                subtype: BinarySubtype::Uuid,
+                bytes,
+            }),
+        ));
+    }
+
+    #[test]
+    fn code_with_scope_uses_recursive_ordered_document_equality() {
+        let stored = Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope {
+            code: "return a".into(),
+            scope: doc! { "a": Bson::Int32(1), "b": "x" },
+        });
+        let equivalent = Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope {
+            code: "return a".into(),
+            scope: doc! { "a": Bson::Int64(1), "b": Bson::Symbol("x".into()) },
+        });
+        let reversed = Bson::JavaScriptCodeWithScope(JavaScriptCodeWithScope {
+            code: "return a".into(),
+            scope: doc! { "b": Bson::Symbol("x".into()), "a": Bson::Int64(1) },
+        });
+
+        assert!(query_values_equal(&stored, &equivalent));
+        assert!(!query_values_equal(&stored, &reversed));
+    }
+
+    #[test]
+    fn regex_candidates_only_match_strings() {
+        let candidate = Bson::RegularExpression(Regex {
+            pattern: "^foo".into(),
+            options: "i".into(),
+        });
+
+        assert!(matches_in(&Bson::String("Food".into()), &[candidate.clone()]).unwrap());
+        assert!(matches_in(
+            &Bson::Array(vec![Bson::String("Food".into())]),
+            &[candidate.clone()],
+        )
+        .unwrap());
+        assert!(!matches_in(&Bson::Int32(42), &[candidate]).unwrap());
+    }
+
+    #[test]
+    fn all_regex_candidates_are_validated_before_matching() {
+        let candidates = [
+            Bson::Int32(1),
+            Bson::RegularExpression(Regex {
+                pattern: "[".into(),
+                options: "".into(),
+            }),
+        ];
+
+        assert!(matches_in(&Bson::Int32(1), &candidates).is_err());
+    }
+
+    #[test]
+    fn array_candidates_match_whole_or_nested_arrays() {
+        let candidate = Bson::Array(vec![Bson::Int32(1), Bson::Int32(2)]);
+
+        assert!(matches_in(
+            &Bson::Array(vec![Bson::Int64(1), Bson::Double(2.0)]),
+            &[candidate.clone()],
+        )
+        .unwrap());
+        assert!(matches_in(
+            &Bson::Array(vec![candidate.clone(), Bson::String("x".into())]),
+            &[candidate],
+        )
+        .unwrap());
+    }
+}

--- a/src/polodb_core/vm/subprogram.rs
+++ b/src/polodb_core/vm/subprogram.rs
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::RefCell;
 use super::label::LabelSlot;
 use super::op::DbOp;
 use crate::coll::collection_info::{CollectionSpecification, IndexInfo};
-use crate::utils::str::escape_binary_to_string;
-use crate::vm::codegen::Codegen;
-use crate::{Result};
-use bson::{Bson, Document};
-use indexmap::IndexMap;
-use std::fmt;
-use std::rc::Rc;
 use crate::errors::FieldTypeUnexpectedStruct;
+use crate::utils::str::escape_binary_to_string;
 use crate::vm::aggregation_codegen_context::AggregationCodeGenContext;
+use crate::vm::codegen::Codegen;
 use crate::vm::global_variable::GlobalVariableSlot;
 use crate::vm::update_operators::UpdateOperator;
 use crate::vm::vm_external_func::VmExternalFunc;
+use crate::Result;
+use bson::{Bson, Document};
+use indexmap::IndexMap;
+use std::cell::RefCell;
+use std::fmt;
+use std::rc::Rc;
 
 pub(crate) struct SubProgramIndexItem {
     pub col_name: String,
@@ -276,7 +276,11 @@ impl SubProgram {
 
         let first = pipeline_vec.first().unwrap();
         if first.len() == 1 && first.contains_key("$match") {
-            return SubProgram::compile_aggregate_with_match(col_spec, pipeline_vec, skip_annotation);
+            return SubProgram::compile_aggregate_with_match(
+                col_spec,
+                pipeline_vec,
+                skip_annotation,
+            );
         }
 
         let mut codegen = Codegen::new(skip_annotation, false);
@@ -329,8 +333,9 @@ impl SubProgram {
                     field_name: "$match".to_string(),
                     expected_ty: "Document".to_string(),
                     actual_ty: name,
-                }.into());
-            },
+                }
+                .into());
+            }
         };
 
         let ctx_ref = Rc::new(RefCell::new(AggregationCodeGenContext::default()));
@@ -358,7 +363,6 @@ impl SubProgram {
 
         Ok(codegen.take())
     }
-
 }
 
 fn open_bson_to_str(val: &Bson) -> Result<String> {
@@ -381,7 +385,6 @@ fn open_bson_to_str(val: &Bson) -> Result<String> {
 
 impl fmt::Display for SubProgram {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-
         for (index, global_var) in self.global_variables.iter().enumerate() {
             writeln!(f, "${} = {:?}", index, global_var.init_value)?;
         }
@@ -636,6 +639,13 @@ impl fmt::Display for SubProgram {
                         pc += 9;
                     }
 
+                    DbOp::GetFieldOrNull => {
+                        let static_id = begin.add(pc + 1).cast::<u32>().read();
+                        let val = &self.static_values[static_id as usize];
+                        writeln!(f, "{}: GetFieldOrNull({})", pc, val)?;
+                        pc += 5;
+                    }
+
                     DbOp::SetField => {
                         let static_id = begin.add(pc + 1).cast::<u32>().read();
                         let val = &self.static_values[static_id as usize];
@@ -678,7 +688,13 @@ impl fmt::Display for SubProgram {
                         let func_id = begin.add(pc + 1).cast::<u32>().read();
                         let external_func = &self.external_funcs[func_id as usize];
                         let param_size = begin.add(pc + 5).cast::<u32>().read();
-                        writeln!(f, "{}: CallExternal(${}, {})", pc, external_func.name(), param_size)?;
+                        writeln!(
+                            f,
+                            "{}: CallExternal(${}, {})",
+                            pc,
+                            external_func.name(),
+                            param_size
+                        )?;
                         pc += 9;
                     }
 
@@ -743,10 +759,10 @@ impl fmt::Display for SubProgram {
 mod tests {
     use crate::coll::collection_info::{CollectionSpecification, IndexInfo};
     use crate::vm::SubProgram;
+    use crate::Error;
     use bson::{doc, Regex};
     use indexmap::indexmap;
     use polodb_line_diff::assert_eq;
-    use crate::Error;
 
     #[inline]
     fn new_spec<T: Into<String>>(name: T) -> CollectionSpecification {
@@ -1222,20 +1238,19 @@ mod tests {
 75: Goto(43)
 
 80: Label(0, "compare_function")
-85: GetField("age", 144)
+85: GetField("age", 131)
 94: PushValue(3)
 99: Greater
-100: FalseJump(144)
+100: FalseJump(131)
 105: Pop2(2)
-110: GetField("child", 144)
-119: GetField("age", 144)
-128: PushValue([1, 2])
-133: In
-134: FalseJump(144)
-139: Pop2(3)
+110: GetFieldOrNull("child.age")
+115: PushValue([1, 2])
+120: In
+121: FalseJump(131)
+126: Pop2(2)
 
-144: Label(1, "compare_function_clean")
-149: Ret0
+131: Label(1, "compare_function_clean")
+136: Ret0
 "#;
         assert_eq!(expect, actual);
     }
@@ -1324,8 +1339,7 @@ mod tests {
             },
         };
         let program =
-            SubProgram::compile_update(&col_spec, &query_doc, &update_doc, false, true)
-                .unwrap();
+            SubProgram::compile_update(&col_spec, &query_doc, &update_doc, false, true).unwrap();
         let actual = format!("Program:\n\n{}", program);
 
         let expect = r#"Program:
@@ -1402,8 +1416,7 @@ mod tests {
             },
         };
         let program =
-            SubProgram::compile_update(&col_spec, &query_doc, &update_doc, false, true)
-                .unwrap();
+            SubProgram::compile_update(&col_spec, &query_doc, &update_doc, false, true).unwrap();
         let actual = format!("Program:\n\n{}", program);
 
         let expect = r#"Program:
@@ -1455,15 +1468,18 @@ mod tests {
     #[test]
     fn test_aggregate_match() {
         let col_spec = new_spec("test");
-        let program = SubProgram::compile_aggregate(&col_spec, vec![
-            doc! {
+        let program = SubProgram::compile_aggregate(
+            &col_spec,
+            vec![doc! {
                 "$match": {
                     "age": {
                         "$gt": 18
                     },
                 },
-            },
-        ], false).unwrap();
+            }],
+            false,
+        )
+        .unwrap();
         let actual = format!("Program:\n\n{}", program);
         let expect = r#"Program:
 
@@ -1509,18 +1525,23 @@ mod tests {
     #[test]
     fn test_aggregate_count() {
         let col_spec = new_spec("test");
-        let program = SubProgram::compile_aggregate(&col_spec, vec![
-            doc! {
-                "$match": {
-                    "age": {
-                        "$gt": 18
+        let program = SubProgram::compile_aggregate(
+            &col_spec,
+            vec![
+                doc! {
+                    "$match": {
+                        "age": {
+                            "$gt": 18
+                        },
                     },
                 },
-            },
-            doc! {
-                "$count": "total",
-            },
-        ], false).unwrap();
+                doc! {
+                    "$count": "total",
+                },
+            ],
+            false,
+        )
+        .unwrap();
         let actual = format!("Program:\n\n{}", program);
 
         let expect = r#"Program:
@@ -1596,11 +1617,14 @@ mod tests {
     #[test]
     fn test_aggregate_count_without_match() {
         let col_spec = new_spec("test");
-        let program = SubProgram::compile_aggregate(&col_spec, vec![
-            doc! {
+        let program = SubProgram::compile_aggregate(
+            &col_spec,
+            vec![doc! {
                 "$count": "total",
-            },
-        ], false).unwrap();
+            }],
+            false,
+        )
+        .unwrap();
         let actual = format!("Program:\n\n{}", program);
         let expect = r#"Program:
 
@@ -1654,16 +1678,18 @@ mod tests {
     #[test]
     fn test_aggregate_error_message() {
         let col_spec = new_spec("test");
-        let program = SubProgram::compile_aggregate(&col_spec, vec![
-            doc! {
+        let program = SubProgram::compile_aggregate(
+            &col_spec,
+            vec![doc! {
                 "$group": {
                     "_id": "$name",
                     "total": {
                         "$sumabc": 1,
                     },
                 },
-            },
-        ], false);
+            }],
+            false,
+        );
         assert!(program.is_err());
         match program {
             Err(Error::InvalidField(i)) => {

--- a/src/polodb_core/vm/vm.rs
+++ b/src/polodb_core/vm/vm.rs
@@ -13,19 +13,17 @@
 // limitations under the License.
 
 use crate::cursor::Cursor;
-use crate::errors::{
-    FieldTypeUnexpectedStruct, RegexError, UnexpectedTypeForOpStruct,
-};
-use crate::index::{IndexHelper, IndexHelperOperation, make_index_key_with_query_key};
+use crate::errors::{FieldTypeUnexpectedStruct, UnexpectedTypeForOpStruct};
+use crate::index::{make_index_key_with_query_key, IndexHelper, IndexHelperOperation};
 use crate::transaction::TransactionInner;
 use crate::vm::op::{generic_cmp, DbOp};
+use crate::vm::query_matcher::{field_path_value, matches_in, matches_regex};
+use crate::vm::vm_external_func::VmExternalFuncStatus;
 use crate::vm::SubProgram;
 use crate::{Error, Metrics, Result};
 use bson::{Bson, Document};
-use regex::RegexBuilder;
 use std::cell::Cell;
 use std::cmp::Ordering;
-use crate::vm::vm_external_func::VmExternalFuncStatus;
 
 macro_rules! try_vm {
     ($self:ident, $action:expr) => {
@@ -205,10 +203,7 @@ impl VM {
         Ok(true)
     }
 
-    fn read_index_value_by_index_key(
-        &mut self,
-        index_key: &[u8],
-    ) -> Result<Option<Bson>> {
+    fn read_index_value_by_index_key(&mut self, index_key: &[u8]) -> Result<Option<Bson>> {
         let slices = crate::utils::bson::split_stacked_keys(index_key)?;
         let pkey = slices.last().expect("pkey must exist");
 
@@ -252,7 +247,7 @@ impl VM {
             );
 
             self.r0 = 1;
-            return Ok(())
+            return Ok(());
         }
 
         self.r0 = 0;
@@ -270,7 +265,8 @@ impl VM {
 
         let index_value = self.index_value.as_ref().expect("index_value must exist");
 
-        let key_buffer = make_index_key_with_query_key(cursor.prefix_bytes.as_slice(), index_value)?;
+        let key_buffer =
+            make_index_key_with_query_key(cursor.prefix_bytes.as_slice(), index_value)?;
 
         let current_key = current_key.unwrap();
         if !current_key.starts_with(key_buffer.as_slice()) {
@@ -462,7 +458,8 @@ impl VM {
             self.stack[frame.stack_begin_pos + i] = self.stack[clone_start_pos + i].clone();
         }
 
-        self.stack.resize(frame.stack_begin_pos + return_size, Bson::Null);
+        self.stack
+            .resize(frame.stack_begin_pos + return_size, Bson::Null);
 
         self.reset_location(frame.return_pos as u32);
     }
@@ -478,7 +475,7 @@ impl VM {
             Some(Bson::Double(d)) => {
                 *d += 1.0;
             }
-            _ => ()
+            _ => (),
         }
     }
 
@@ -631,7 +628,7 @@ impl VM {
                                     0
                                 }
                             }
-                            _ => panic!("store r0 failed")
+                            _ => panic!("store r0 failed"),
                         };
                         self.pc = self.pc.add(1);
                     }
@@ -674,6 +671,21 @@ impl VM {
                                 self.reset_location(location);
                             }
                         }
+                    }
+
+                    DbOp::GetFieldOrNull => {
+                        let key_stat_id = self.pc.add(1).cast::<u32>().read();
+                        let key = self.borrow_static(key_stat_id as usize);
+                        let key_name = key.as_str().unwrap();
+                        let value = self
+                            .stack
+                            .last()
+                            .and_then(Bson::as_document)
+                            .and_then(|document| field_path_value(document, key_name))
+                            .unwrap_or(Bson::Null);
+
+                        self.stack.push(value);
+                        self.pc = self.pc.add(5);
                     }
 
                     DbOp::UnsetField => {
@@ -813,15 +825,8 @@ impl VM {
                         let top1 = &self.stack[self.stack.len() - 1];
                         let top2 = &self.stack[self.stack.len() - 2];
 
-                        self.r0 = 0;
-
-                        for item in top1.as_array().unwrap().iter() {
-                            let cmp_result = crate::utils::bson::value_cmp(top2, item);
-                            if let Ok(Ordering::Equal) = cmp_result {
-                                self.r0 = 1;
-                                break;
-                            }
-                        }
+                        let matches = try_vm!(self, matches_in(top2, top1.as_array().unwrap()));
+                        self.r0 = i32::from(matches);
 
                         self.pc = self.pc.add(1);
                     }
@@ -836,62 +841,19 @@ impl VM {
                         let val1 = &self.stack[self.stack.len() - 2];
                         let val2 = &self.stack[self.stack.len() - 1];
 
-                        self.r0 = 0;
-
-                        if let Bson::RegularExpression(re) = val2 {
-                            let mut re_build = RegexBuilder::new(re.pattern.as_str());
-                            for char in re.options.chars() {
-                                match char {
-                                    'i' => {
-                                        re_build.case_insensitive(true);
-                                    }
-                                    'm' => {
-                                        re_build.multi_line(true);
-                                    }
-                                    's' => {
-                                        re_build.dot_matches_new_line(true);
-                                    }
-                                    'u' => {
-                                        re_build.unicode(true);
-                                    }
-                                    'U' => {
-                                        re_build.swap_greed(true);
-                                    }
-                                    'x' => {
-                                        re_build.ignore_whitespace(true);
-                                    }
-                                    _ => {
-                                        return Err(Error::from(RegexError {
-                                            error: format!("unknown regex option: {}", char),
-                                            expression: re.pattern.clone(),
-                                            options: re.options.clone(),
-                                        }));
-                                    }
-                                }
+                        let matches = match val2 {
+                            Bson::RegularExpression(expression) => {
+                                try_vm!(self, matches_regex(val1, expression))
                             }
-
-                            let re_build = re_build.build().map_err(|err| {
-                                Error::from(RegexError {
-                                    error: format!("regex build error: {err}"),
-                                    expression: re.pattern.clone(),
-                                    options: re.options.clone(),
-                                })
-                            })?;
-
-                            if re_build.is_match(&val1.to_string()) {
-                                self.r0 = 1;
-                            }
-                        }
+                            _ => false,
+                        };
+                        self.r0 = i32::from(matches);
 
                         self.pc = self.pc.add(1);
                     }
 
-                    DbOp::Not =>{
-                        self.r0 = if self.r0 == 0 {
-                            1
-                        } else {
-                            0
-                        };
+                    DbOp::Not => {
+                        self.r0 = if self.r0 == 0 { 1 } else { 0 };
 
                         self.pc = self.pc.add(1);
                     }
@@ -960,7 +922,8 @@ impl VM {
                         let params = &self.stack[self.stack.len() - size_of_param..];
                         let result = try_vm!(self, func.call(params));
                         // pop params
-                        self.stack.resize(self.stack.len() - size_of_param, Bson::Null);
+                        self.stack
+                            .resize(self.stack.len() - size_of_param, Bson::Null);
                         self.r0 = match result {
                             VmExternalFuncStatus::Continue => {
                                 self.stack.push(Bson::Null);
@@ -991,11 +954,7 @@ impl VM {
                         let id = self.pc.add(1).cast::<u32>().read();
                         let func = &self.program.external_funcs[id as usize];
 
-                        self.r0 = if func.is_completed() {
-                            1
-                        } else {
-                            0
-                        };
+                        self.r0 = if func.is_completed() { 1 } else { 0 };
 
                         self.pc = self.pc.add(5);
                     }
@@ -1011,7 +970,8 @@ impl VM {
 
                     DbOp::IfFalseRet => {
                         let return_size = self.pc.add(1).cast::<u32>().read() as usize;
-                        if self.r0 == 0 {  // false
+                        if self.r0 == 0 {
+                            // false
                             self.ret(return_size);
                         } else {
                             self.pc = self.pc.add(5);


### PR DESCRIPTION
## Summary

- match `$in`/`$nin` candidates against scalar fields, full arrays, and direct stored-array elements
- add recursive MongoDB-style BSON equality for numeric types, ordered arrays/documents, String/Symbol, binary values, DBRefs, and CodeWithScope
- support regex candidates against strings, symbols, and direct stored-array elements
- preserve missing/null semantics across `$in`, `$nin`, and `$not`, including dotted document paths
- validate invalid operands, operator documents, and regex candidates before execution

## Root cause

`DbOp::In` compared the entire stored BSON value with each candidate, so an array field could not match one of its elements. `$nin` also used the wrong branch polarity and could preserve positive `$in` results.

## MongoDB compatibility

This covers direct stored arrays, exact and nested arrays, Int32/Int64/Double equality, ordered documents, DBRef literals, String/Symbol equivalence, BSON regex literals, and null/missing negations.

Known boundaries intentionally left out of this PR:

- Decimal128 cross-type numeric equality
- complete PCRE2 syntax parity
- dotted traversal through intermediate arrays
- multikey/index optimization

## Validation

- `cargo test -p polodb_core --lib vm::query_matcher`
- `cargo test -p polodb_core --test test_in`
- `cargo test --locked --release --workspace --exclude py-binding-polodb`
- `cargo build --locked --release --workspace --exclude py-binding-polodb`
- `git diff --check`
- intended-file `rustfmt --check`

Supersedes #129. Original report and implementation direction by @DataHearth.
