### PR TITLE
feat: add MongoDB-style $all query matching

### DIFF
--- a/src/polodb_core/tests/test_all.rs
+++ b/src/polodb_core/tests/test_all.rs
@@ -1,0 +1,540 @@
+// Copyright 2024 Vincent Chan
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bson::oid::ObjectId;
+use bson::{doc, Bson, Document, Regex};
+use polodb_core::{Collection, CollectionT};
+
+mod common;
+
+use common::prepare_db;
+
+fn matching_ids(collection: &Collection<Document>, filter: Document) -> Vec<String> {
+    let mut ids = collection
+        .find(filter)
+        .run()
+        .unwrap()
+        .map(|result| result.unwrap().get_str("_id").unwrap().to_owned())
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids
+}
+
+fn assert_matching_ids(collection: &Collection<Document>, filter: Document, expected: &[&str]) {
+    let mut expected = expected
+        .iter()
+        .map(|id| (*id).to_owned())
+        .collect::<Vec<_>>();
+    expected.sort();
+    assert_eq!(matching_ids(collection, filter), expected);
+}
+
+#[test]
+fn test_all_matches_scalars_arrays_and_every_candidate() {
+    let db = prepare_db("test-all-scalars-and-arrays").unwrap();
+    let collection = db.collection::<Document>("items");
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "scalar_one", "value": 1 },
+            doc! { "_id": "scalar_two", "value": 2 },
+            doc! { "_id": "array_one", "value": [1] },
+            doc! { "_id": "array_12", "value": [1, 2] },
+            doc! { "_id": "array_21", "value": [2, 1] },
+            doc! { "_id": "array_123", "value": [1, 2, 3] },
+            doc! { "_id": "empty", "value": Bson::Array(Vec::new()) },
+            doc! { "_id": "missing" },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [2] } },
+        &["array_12", "array_123", "array_21", "scalar_two"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [1, 2] } },
+        &["array_12", "array_123", "array_21"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [2, 1] } },
+        &["array_12", "array_123", "array_21"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [1, 1] } },
+        &[
+            "array_12",
+            "array_123",
+            "array_21",
+            "array_one",
+            "scalar_one",
+        ],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": Bson::Array(Vec::new()) } },
+        &[],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$not": { "$all": Bson::Array(Vec::new()) } } },
+        &[
+            "array_12",
+            "array_123",
+            "array_21",
+            "array_one",
+            "empty",
+            "missing",
+            "scalar_one",
+            "scalar_two",
+        ],
+    );
+}
+
+#[test]
+fn test_all_matches_exact_and_directly_nested_arrays() {
+    let db = prepare_db("test-all-nested-arrays").unwrap();
+    let collection = db.collection::<Document>("items");
+    let one_two = Bson::Array(vec![Bson::Int32(1), Bson::Int32(2)]);
+    let two_one = Bson::Array(vec![Bson::Int32(2), Bson::Int32(1)]);
+    let empty_array = Bson::Array(Vec::new());
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "exact", "value": one_two.clone() },
+            doc! { "_id": "reordered", "value": two_one.clone() },
+            doc! { "_id": "nested", "value": [one_two.clone(), Bson::Int32(3)] },
+            doc! { "_id": "nested_reordered", "value": [two_one] },
+            doc! { "_id": "too_deep", "value": [[one_two.clone()]] },
+            doc! { "_id": "other", "value": [[1, 3]] },
+            doc! { "_id": "exact_empty", "value": empty_array.clone() },
+            doc! { "_id": "nested_empty", "value": [empty_array.clone()] },
+            doc! { "_id": "too_deep_empty", "value": [[empty_array.clone()]] },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [one_two.clone()] } },
+        &["exact", "nested"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [one_two, 3] } },
+        &["nested"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [empty_array] } },
+        &["exact_empty", "nested_empty"],
+    );
+}
+
+#[test]
+fn test_all_uses_equivalent_numeric_types() {
+    let db = prepare_db("test-all-numeric-equality").unwrap();
+    let collection = db.collection::<Document>("items");
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "int32", "value": Bson::Int32(7) },
+            doc! { "_id": "int64", "value": Bson::Int64(7) },
+            doc! { "_id": "double", "value": Bson::Double(7.0) },
+            doc! {
+                "_id": "mixed",
+                "value": [
+                    Bson::Int32(7),
+                    Bson::Double(-0.0),
+                    Bson::Int64(9_007_199_254_740_992),
+                ],
+            },
+            doc! {
+                "_id": "large_next",
+                "value": Bson::Int64(9_007_199_254_740_993),
+            },
+            doc! { "_id": "i64_min", "value": Bson::Int64(i64::MIN) },
+            doc! { "_id": "i64_max", "value": Bson::Int64(i64::MAX) },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [Bson::Int64(7)] } },
+        &["double", "int32", "int64", "mixed"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! {
+            "value": {
+                "$all": [Bson::Double(0.0), Bson::Double(9_007_199_254_740_992.0)]
+            }
+        },
+        &["mixed"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [Bson::Double(9_007_199_254_740_992.0)] } },
+        &["mixed"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [Bson::Double(9_223_372_036_854_775_808.0)] } },
+        &[],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [Bson::Double(-9_223_372_036_854_775_808.0)] } },
+        &["i64_min"],
+    );
+}
+
+#[test]
+fn test_all_uses_ordered_bson_equality_and_string_symbol_equivalence() {
+    let db = prepare_db("test-all-bson-equality").unwrap();
+    let collection = db.collection::<Document>("items");
+
+    let ordered = doc! { "a": 1, "b": 2 };
+    let reversed = doc! { "b": 2, "a": 1 };
+    let db_ref = doc! { "$ref": "targets", "$id": ObjectId::new() };
+    let ref_literal = doc! { "$ref": "targets" };
+    let ref_operator_literal = doc! { "$ref": "targets", "$gt": 1 };
+    let id_first_literal = doc! { "$id": 7, "$ref": "targets" };
+    let db_first_literal = doc! { "$db": "app", "$ref": "targets", "$id": 7 };
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "ordered", "value": ordered.clone() },
+            doc! { "_id": "reversed", "value": reversed.clone() },
+            doc! { "_id": "array_ordered", "value": [ordered.clone()] },
+            doc! { "_id": "db_ref", "value": db_ref.clone() },
+            doc! { "_id": "ref_literal", "value": ref_literal.clone() },
+            doc! { "_id": "ref_operator_literal", "value": ref_operator_literal.clone() },
+            doc! { "_id": "id_first_literal", "value": id_first_literal.clone() },
+            doc! { "_id": "db_first_literal", "value": db_first_literal.clone() },
+            doc! { "_id": "string", "value": "alpha" },
+            doc! { "_id": "symbol", "value": Bson::Symbol("alpha".into()) },
+            doc! {
+                "_id": "symbol_string_array",
+                "value": [Bson::Symbol("alpha".into()), Bson::String("beta".into())],
+            },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [Bson::Document(ordered)] } },
+        &["array_ordered", "ordered"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [Bson::Document(reversed)] } },
+        &["reversed"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [Bson::Document(db_ref)] } },
+        &["db_ref"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [Bson::Document(ref_literal)] } },
+        &["ref_literal"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [Bson::Document(ref_operator_literal)] } },
+        &["ref_operator_literal"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [Bson::Document(id_first_literal)] } },
+        &["id_first_literal"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [Bson::Document(db_first_literal)] } },
+        &["db_first_literal"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": ["alpha"] } },
+        &["string", "symbol", "symbol_string_array"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! {
+            "value": {
+                "$all": [Bson::Symbol("alpha".into()), Bson::Symbol("beta".into())]
+            }
+        },
+        &["symbol_string_array"],
+    );
+}
+
+#[test]
+fn test_all_regex_candidates_match_strings_and_are_validated_eagerly() {
+    let db = prepare_db("test-all-regex").unwrap();
+    let collection = db.collection::<Document>("items");
+
+    let alice_regex = Regex {
+        pattern: "^ali".into(),
+        options: "i".into(),
+    };
+    let carol_regex = Regex {
+        pattern: "^car".into(),
+        options: "i".into(),
+    };
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "scalar", "value": "Alice" },
+            doc! { "_id": "array", "value": ["Alice", "Carol"] },
+            doc! { "_id": "symbol", "value": Bson::Symbol("ALICE".into()) },
+            doc! {
+                "_id": "symbol_array",
+                "value": [Bson::Symbol("Alice".into()), Bson::Symbol("Carol".into())],
+            },
+            doc! {
+                "_id": "stored_regex",
+                "value": Bson::RegularExpression(alice_regex.clone()),
+            },
+            doc! {
+                "_id": "regex_array",
+                "value": [Bson::RegularExpression(alice_regex.clone())],
+            },
+            doc! { "_id": "other", "value": "David" },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! {
+            "value": {
+                "$all": [Bson::RegularExpression(alice_regex.clone())]
+            }
+        },
+        &[
+            "array",
+            "regex_array",
+            "scalar",
+            "stored_regex",
+            "symbol",
+            "symbol_array",
+        ],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! {
+            "value": {
+                "$all": [
+                    Bson::RegularExpression(alice_regex),
+                    Bson::RegularExpression(carol_regex),
+                ]
+            }
+        },
+        &["array", "symbol_array"],
+    );
+
+    assert!(collection
+        .find(doc! {
+            "value": {
+                "$all": ["does-not-match", Bson::RegularExpression(Regex {
+                    pattern: "[".into(),
+                    options: "".into(),
+                })]
+            }
+        })
+        .run()
+        .is_err());
+    assert!(collection
+        .find(doc! {
+            "value": {
+                "$all": [Bson::RegularExpression(Regex {
+                    pattern: "Alice".into(),
+                    options: "q".into(),
+                })]
+            }
+        })
+        .run()
+        .is_err());
+
+    db.create_collection("empty").unwrap();
+    let empty_collection = db.collection::<Document>("empty");
+    assert!(empty_collection
+        .find(doc! {
+            "value": {
+                "$all": [Bson::RegularExpression(Regex {
+                    pattern: "[".into(),
+                    options: "".into(),
+                })]
+            }
+        })
+        .run()
+        .is_err());
+}
+
+#[test]
+fn test_all_and_not_handle_null_and_missing_fields() {
+    let db = prepare_db("test-all-null-and-missing").unwrap();
+    let collection = db.collection::<Document>("items");
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "null", "value": Bson::Null },
+            doc! { "_id": "missing" },
+            doc! { "_id": "array_null", "value": [Bson::Null] },
+            doc! { "_id": "array_null_one", "value": [Bson::Null, Bson::Int32(1)] },
+            doc! { "_id": "one", "value": 1 },
+            doc! { "_id": "array_one", "value": [1] },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [Bson::Null] } },
+        &["array_null", "array_null_one", "missing", "null"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$not": { "$all": [Bson::Null] } } },
+        &["array_one", "one"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [Bson::Null, Bson::Int64(1)] } },
+        &["array_null_one"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$not": { "$all": [Bson::Null, 1] } } },
+        &["array_null", "array_one", "missing", "null", "one"],
+    );
+}
+
+#[test]
+fn test_all_handles_dotted_document_paths() {
+    let db = prepare_db("test-all-dotted-paths").unwrap();
+    let collection = db.collection::<Document>("items");
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "ada", "profile": { "names": ["Ada", "Lovelace"] } },
+            doc! { "_id": "grace", "profile": { "names": "Grace" } },
+            doc! { "_id": "explicit_null", "profile": { "names": Bson::Null } },
+            doc! { "_id": "leaf_missing", "profile": {} },
+            doc! { "_id": "middle_missing" },
+            doc! { "_id": "middle_scalar", "profile": "legacy" },
+        ])
+        .unwrap();
+
+    assert_matching_ids(
+        &collection,
+        doc! { "profile.names": { "$all": ["Ada", "Lovelace"] } },
+        &["ada"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "profile.names": { "$all": ["Grace"] } },
+        &["grace"],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "profile.names": { "$all": [Bson::Null] } },
+        &[
+            "explicit_null",
+            "leaf_missing",
+            "middle_missing",
+            "middle_scalar",
+        ],
+    );
+    assert_matching_ids(
+        &collection,
+        doc! { "profile.names": { "$not": { "$all": ["Ada"] } } },
+        &[
+            "explicit_null",
+            "grace",
+            "leaf_missing",
+            "middle_missing",
+            "middle_scalar",
+        ],
+    );
+}
+
+#[test]
+fn test_all_validates_operands_and_rejects_operator_documents() {
+    let db = prepare_db("test-all-invalid-operands").unwrap();
+    let collection = db.collection::<Document>("items");
+    let literal = doc! { "x": 1, "$regex": "literal" };
+
+    collection
+        .insert_many(vec![
+            doc! { "_id": "one", "value": "Alice" },
+            doc! { "_id": "literal", "value": literal.clone() },
+        ])
+        .unwrap();
+
+    assert!(collection
+        .find(doc! { "value": { "$all": "Alice" } })
+        .run()
+        .is_err());
+    assert!(collection
+        .find(doc! { "value": { "$all": Bson::Document(doc! { "x": 1 }) } })
+        .run()
+        .is_err());
+    assert!(collection
+        .find(doc! {
+            "value": {
+                "$all": [Bson::Document(doc! { "$gt": 1 })]
+            }
+        })
+        .run()
+        .is_err());
+    assert!(collection
+        .find(doc! {
+            "value": {
+                "$all": [Bson::Document(doc! { "$regex": "^Ali" })]
+            }
+        })
+        .run()
+        .is_err());
+    assert!(collection
+        .find(doc! {
+            "value": {
+                "$all": [Bson::Document(doc! { "$elemMatch": { "x": 1 } })]
+            }
+        })
+        .run()
+        .is_err());
+    assert!(collection
+        .find(doc! {
+            "value": {
+                "$all": [Bson::Document(doc! {
+                    "$gt": 1,
+                    "$ref": "targets",
+                    "$id": 7,
+                })]
+            }
+        })
+        .run()
+        .is_err());
+
+    assert_matching_ids(
+        &collection,
+        doc! { "value": { "$all": [Bson::Document(literal)] } },
+        &["literal"],
+    );
+}

--- a/src/polodb_core/vm/codegen.rs
+++ b/src/polodb_core/vm/codegen.rs
@@ -20,7 +20,7 @@ use crate::vm::aggregation_codegen_context::{AggregationCodeGenContext, Pipeline
 use crate::vm::global_variable::{GlobalVariable, GlobalVariableSlot};
 use crate::vm::op::DbOp;
 use crate::vm::operators::OpRegistry;
-use crate::vm::query_matcher::validate_in_candidates;
+use crate::vm::query_matcher::validate_membership_candidates;
 use crate::vm::subprogram::SubProgramIndexItem;
 use crate::vm::update_operators::{
     IncOperator, MaxOperator, MinOperator, MulOperator, PopOperator, PushOperator, RenameOperator,
@@ -41,6 +41,17 @@ use bson::{Array, Binary, Bson, Document};
 
 const JUMP_TABLE_DEFAULT_SIZE: usize = 8;
 const PATH_DEFAULT_SIZE: usize = 8;
+
+fn is_in_literal_dollar_document(document: &Document) -> bool {
+    document.contains_key("$ref") && document.contains_key("$id")
+}
+
+fn is_all_literal_dollar_document(document: &Document) -> bool {
+    document
+        .keys()
+        .next()
+        .is_some_and(|key| matches!(key.as_str(), "$ref" | "$id" | "$db"))
+}
 
 pub(super) struct Codegen {
     program: Box<SubProgram>,
@@ -596,7 +607,11 @@ impl Codegen {
         }
     }
 
-    fn validate_in_operand<'a>(&self, value: &'a Bson) -> Result<&'a Array> {
+    fn validate_array_query_operand<'a>(
+        &self,
+        value: &'a Bson,
+        is_literal_dollar_document: fn(&Document) -> bool,
+    ) -> Result<&'a Array> {
         let values = match value {
             Bson::Array(values) => values,
             _ => {
@@ -614,8 +629,10 @@ impl Codegen {
                     if document
                         .keys()
                         .next()
-                        .is_some_and(|key| key.starts_with('$'))
-                        && !(document.contains_key("$ref") && document.contains_key("$id"))
+                        .is_some_and(|key| {
+                            key.starts_with('$')
+                                && !is_literal_dollar_document(document)
+                        })
             )
         }) {
             return Err(Error::InvalidField(mk_invalid_query_field(
@@ -624,8 +641,16 @@ impl Codegen {
             )));
         }
 
-        validate_in_candidates(values)?;
+        validate_membership_candidates(values)?;
         Ok(values)
+    }
+
+    fn validate_in_operand<'a>(&self, value: &'a Bson) -> Result<&'a Array> {
+        self.validate_array_query_operand(value, is_in_literal_dollar_document)
+    }
+
+    fn validate_all_operand<'a>(&self, value: &'a Bson) -> Result<&'a Array> {
+        self.validate_array_query_operand(value, is_all_literal_dollar_document)
     }
 
     fn emit_query_tuple_document_kv(
@@ -686,6 +711,21 @@ impl Codegen {
                 let stat_val_id = self.push_static(sub_value.clone());
                 self.emit_push_value(stat_val_id);
                 self.emit_logical(DbOp::In, is_in_not);
+
+                self.emit_goto(DbOp::IfFalse, not_found_label);
+
+                self.emit(DbOp::Pop2);
+                self.emit_u32((field_size + 1) as u32);
+            }
+
+            "$all" => {
+                self.validate_all_operand(sub_value)?;
+
+                let field_size = self.get_field_or_null(key);
+
+                let stat_val_id = self.push_static(sub_value.clone());
+                self.emit_push_value(stat_val_id);
+                self.emit_logical(DbOp::All, is_in_not);
 
                 self.emit_goto(DbOp::IfFalse, not_found_label);
 

--- a/src/polodb_core/vm/op.rs
+++ b/src/polodb_core/vm/op.rs
@@ -228,6 +228,10 @@ pub enum DbOp {
     // the result is stored in r0
     In,
 
+    // check if every value in top0 matches top2
+    // the result is stored in r0
+    All,
+
     EqualNull,
 
     // open a cursor with op0 as root_pid

--- a/src/polodb_core/vm/query_matcher.rs
+++ b/src/polodb_core/vm/query_matcher.rs
@@ -31,35 +31,26 @@ pub(super) fn field_path_value(document: &Document, path: &str) -> Option<Bson> 
 }
 
 pub(super) fn matches_in(field_value: &Bson, candidates: &[Bson]) -> Result<bool> {
-    let compiled_regexes = compile_in_regexes(candidates)?;
+    let compiled_regexes = compile_candidate_regexes(candidates)?;
 
-    for (candidate, compiled_regex) in candidates.iter().zip(compiled_regexes.iter()) {
-        if query_values_equal(field_value, candidate) {
-            return Ok(true);
-        }
-
-        if let Bson::Array(values) = field_value {
-            if values
-                .iter()
-                .any(|value| query_values_equal(value, candidate))
-            {
-                return Ok(true);
-            }
-        }
-
-        if compiled_regex
-            .as_ref()
-            .is_some_and(|regex| matches_compiled_regex(field_value, regex))
-        {
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
+    Ok(candidates
+        .iter()
+        .zip(compiled_regexes.iter())
+        .any(|(candidate, regex)| candidate_matches(field_value, candidate, regex.as_ref())))
 }
 
-pub(super) fn validate_in_candidates(candidates: &[Bson]) -> Result<()> {
-    compile_in_regexes(candidates).map(|_| ())
+pub(super) fn matches_all(field_value: &Bson, candidates: &[Bson]) -> Result<bool> {
+    let compiled_regexes = compile_candidate_regexes(candidates)?;
+
+    Ok(!candidates.is_empty()
+        && candidates
+            .iter()
+            .zip(compiled_regexes.iter())
+            .all(|(candidate, regex)| candidate_matches(field_value, candidate, regex.as_ref())))
+}
+
+pub(super) fn validate_membership_candidates(candidates: &[Bson]) -> Result<()> {
+    compile_candidate_regexes(candidates).map(|_| ())
 }
 
 pub(super) fn matches_regex(field_value: &Bson, expression: &Regex) -> Result<bool> {
@@ -78,7 +69,23 @@ fn matches_compiled_regex(field_value: &Bson, regex: &CompiledRegex) -> bool {
     }
 }
 
-fn compile_in_regexes(candidates: &[Bson]) -> Result<Vec<Option<CompiledRegex>>> {
+fn candidate_matches(
+    field_value: &Bson,
+    candidate: &Bson,
+    compiled_regex: Option<&CompiledRegex>,
+) -> bool {
+    query_values_equal(field_value, candidate)
+        || matches!(
+            field_value,
+            Bson::Array(values)
+                if values
+                    .iter()
+                    .any(|value| query_values_equal(value, candidate))
+        )
+        || compiled_regex.is_some_and(|regex| matches_compiled_regex(field_value, regex))
+}
+
+fn compile_candidate_regexes(candidates: &[Bson]) -> Result<Vec<Option<CompiledRegex>>> {
     candidates
         .iter()
         .map(|candidate| match candidate {
@@ -188,7 +195,7 @@ mod tests {
     use bson::spec::BinarySubtype;
     use bson::{doc, Binary, Bson, JavaScriptCodeWithScope, Regex};
 
-    use super::{field_path_value, matches_in, query_values_equal};
+    use super::{field_path_value, matches_all, matches_in, query_values_equal};
 
     #[test]
     fn field_path_lookup_preserves_terminal_documents() {
@@ -294,7 +301,7 @@ mod tests {
     }
 
     #[test]
-    fn all_regex_candidates_are_validated_before_matching() {
+    fn in_validates_all_regex_candidates_before_matching() {
         let candidates = [
             Bson::Int32(1),
             Bson::RegularExpression(Regex {
@@ -320,5 +327,45 @@ mod tests {
             &[candidate],
         )
         .unwrap());
+    }
+
+    #[test]
+    fn all_candidates_must_match_and_empty_candidates_never_match() {
+        let field = Bson::Array(vec![Bson::Int32(1), Bson::Int64(2)]);
+
+        assert!(
+            matches_all(&field, &[Bson::Double(1.0), Bson::Int32(2), Bson::Int64(2)],).unwrap()
+        );
+        assert!(!matches_all(&field, &[Bson::Int32(1), Bson::Int32(3)]).unwrap());
+        assert!(!matches_all(&field, &[]).unwrap());
+    }
+
+    #[test]
+    fn all_array_candidates_match_whole_or_nested_arrays() {
+        let candidate = Bson::Array(vec![Bson::Int32(1), Bson::Int32(2)]);
+
+        assert!(matches_all(
+            &Bson::Array(vec![Bson::Int64(1), Bson::Double(2.0)]),
+            std::slice::from_ref(&candidate),
+        )
+        .unwrap());
+        assert!(matches_all(
+            &Bson::Array(vec![candidate.clone(), Bson::String("x".into())]),
+            &[candidate],
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn all_validates_all_regex_candidates_before_matching() {
+        let candidates = [
+            Bson::Int32(3),
+            Bson::RegularExpression(Regex {
+                pattern: "[".into(),
+                options: "".into(),
+            }),
+        ];
+
+        assert!(matches_all(&Bson::Int32(1), &candidates).is_err());
     }
 }

--- a/src/polodb_core/vm/subprogram.rs
+++ b/src/polodb_core/vm/subprogram.rs
@@ -595,6 +595,11 @@ impl fmt::Display for SubProgram {
                         pc += 1;
                     }
 
+                    DbOp::All => {
+                        writeln!(f, "{}: All", pc)?;
+                        pc += 1;
+                    }
+
                     DbOp::EqualNull => {
                         writeln!(f, "{}: EqualNull", pc)?;
                         pc += 1;
@@ -1251,6 +1256,61 @@ mod tests {
 
 131: Label(1, "compare_function_clean")
 136: Ret0
+"#;
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
+    fn print_not_all() {
+        let col_spec = new_spec("test");
+        let test_doc = doc! {
+            "tags": {
+                "$not": {
+                    "$all": [1, 2],
+                },
+            },
+        };
+        let program = SubProgram::compile_query(&col_spec, &test_doc, false).unwrap();
+        let actual = format!("Program:\n\n{}", program);
+
+        let expect = r#"Program:
+
+0: OpenRead("test")
+5: Rewind(25)
+10: Goto(55)
+
+15: Label(3)
+20: Next(55)
+
+25: Label(6, "close")
+30: Close
+31: Halt
+
+32: Label(5, "not_this_item")
+37: Pop
+38: Goto(15)
+
+43: Label(4, "result")
+48: ResultRow
+49: Pop
+50: Goto(15)
+
+55: Label(2, "compare")
+60: Dup
+61: Call(80, 1)
+70: FalseJump(32)
+75: Goto(43)
+
+80: Label(0, "compare_function")
+85: GetFieldOrNull("tags")
+90: PushValue([1, 2])
+95: All
+96: Not
+97: FalseJump(107)
+102: Pop2(2)
+
+107: Label(1, "compare_function_clean")
+112: Ret0
 "#;
         assert_eq!(expect, actual);
     }

--- a/src/polodb_core/vm/vm.rs
+++ b/src/polodb_core/vm/vm.rs
@@ -17,7 +17,7 @@ use crate::errors::{FieldTypeUnexpectedStruct, UnexpectedTypeForOpStruct};
 use crate::index::{make_index_key_with_query_key, IndexHelper, IndexHelperOperation};
 use crate::transaction::TransactionInner;
 use crate::vm::op::{generic_cmp, DbOp};
-use crate::vm::query_matcher::{field_path_value, matches_in, matches_regex};
+use crate::vm::query_matcher::{field_path_value, matches_all, matches_in, matches_regex};
 use crate::vm::vm_external_func::VmExternalFuncStatus;
 use crate::vm::SubProgram;
 use crate::{Error, Metrics, Result};
@@ -826,6 +826,16 @@ impl VM {
                         let top2 = &self.stack[self.stack.len() - 2];
 
                         let matches = try_vm!(self, matches_in(top2, top1.as_array().unwrap()));
+                        self.r0 = i32::from(matches);
+
+                        self.pc = self.pc.add(1);
+                    }
+
+                    DbOp::All => {
+                        let top1 = &self.stack[self.stack.len() - 1];
+                        let top2 = &self.stack[self.stack.len() - 2];
+
+                        let matches = try_vm!(self, matches_all(top2, top1.as_array().unwrap()));
                         self.r0 = i32::from(matches);
 
                         self.pc = self.pc.add(1);


### PR DESCRIPTION
## Summary

- add MongoDB-style `$all` matching for scalar fields, arrays, nested arrays, regex candidates, and negation
- reuse the shared BSON query equality from `$in` for cross-numeric comparison, ordered documents/arrays, String/Symbol, binary values, DBRef-shaped literals, and CodeWithScope
- preserve null/missing behavior through `GetFieldOrNull`
- validate malformed operands, unsupported operator documents, and every regex candidate before execution

## Semantics

A non-empty `$all` candidate list matches only when every candidate independently matches either the complete stored value or a direct element of a stored array. Duplicate candidates may be satisfied by the same stored element. An empty candidate list matches no documents, and `$not + $all` remains the exact complement.

DBRef-shaped dollar documents use MongoDB first-key handling for `$ref`, `$id`, and `$db`. The distinct existing `$in/$nin` DBRef validation rule is preserved.

## Implementation

- add a shared single-candidate matcher and `matches_all`
- add the one-byte `DbOp::All` opcode with codegen, VM, and disassembler support
- add an exact bytecode snapshot for `$not + $all`
- add eight integration tests covering scalar/array matching, nested arrays, numeric equality boundaries, ordered BSON equality, regexes, null/missing fields, dotted document paths, and validation

## Known boundaries

This PR intentionally does not implement:

- `$all + $elemMatch`
- Decimal128 cross-type numeric equality
- complete MongoDB PCRE2 syntax parity
- dotted traversal through intermediate arrays
- unknown dollar-first literal documents outside the supported DBRef-shaped forms
- multikey/index optimization

## Validation

- `cargo test -p polodb_core`
- `cargo test --locked --release --workspace --exclude py-binding-polodb`
- `cargo build --locked --release --workspace --exclude py-binding-polodb`
- intended-file `rustfmt --check`
- `git diff --check`

Supersedes #128. Thank you @DataHearth for the original proposal and implementation direction.