### PR TITLE
fix(core): use platform c_char for RocksDB FFI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,8 @@ jobs:
         include:
           - name: Ubuntu
             os: ubuntu-latest
+          - name: Ubuntu ARM64
+            os: ubuntu-24.04-arm
           - name: macOS
             os: macos-latest
           - name: Windows
@@ -46,7 +48,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run Rust tests
         run: cargo test --locked --release --verbose --workspace --exclude py-binding-polodb

--- a/src/polodb_core/db/rocksdb_iterator.rs
+++ b/src/polodb_core/db/rocksdb_iterator.rs
@@ -103,7 +103,7 @@ impl RocksDBIteratorInner {
 
     pub fn seek(&self, key: &[u8]) {
         unsafe {
-            ffi::rocksdb_iter_seek(self.inner, key.as_ptr() as *const i8, key.len());
+            ffi::rocksdb_iter_seek(self.inner, key.as_ptr().cast::<c_char>(), key.len());
         }
     }
 

--- a/src/polodb_core/db/rocksdb_transaction.rs
+++ b/src/polodb_core/db/rocksdb_transaction.rs
@@ -130,9 +130,9 @@ impl RocksDBTransactionInner {
 
             ffi::rocksdb_transaction_put(
                 self.inner,
-                key.as_ptr() as *const i8,
+                key.as_ptr().cast::<c_char>(),
                 key.len(),
-                value.as_ptr() as *const i8,
+                value.as_ptr().cast::<c_char>(),
                 value.len(),
                 &mut err,
             );
@@ -149,7 +149,7 @@ impl RocksDBTransactionInner {
             let value = ffi::rocksdb_transaction_get(
                 self.inner,
                 self.read_options.get(),
-                key.as_ptr() as *const i8,
+                key.as_ptr().cast::<c_char>(),
                 key.len(),
                 &mut value_len,
                 &mut err,
@@ -172,7 +172,7 @@ impl RocksDBTransactionInner {
 
             ffi::rocksdb_transaction_delete(
                 self.inner,
-                key.as_ptr() as *const i8,
+                key.as_ptr().cast::<c_char>(),
                 key.len(),
                 &mut err,
             );


### PR DESCRIPTION
## Summary

- cast RocksDB transaction and iterator byte buffers to `libc::c_char` instead of hard-coding `i8`
- add native Ubuntu ARM64 coverage to the Rust Core CI matrix
- isolate Cargo/RocksDB caches by runner architecture

## Root cause

Bindgen follows the target C ABI, where `c_char` is unsigned on AArch64 Linux. PoloDB forced the arguments to `*const i8`, so the generated `*const u8` RocksDB signatures failed to compile on Raspberry Pi 5 and other AArch64 Linux systems.

## Impact

This restores AArch64 Linux compilation without changing PoloDB's public API, RocksDB ABI, or database format. The ARM64 matrix remains covered by the existing `Rust / Required CI Gate`.

## Validation

- `cargo test --locked --release -p polodb_core` — passed
- `cargo build --locked --release --workspace --exclude py-binding-polodb` — passed
- `git diff --check` — passed
- workflow YAML parse — passed

`cargo fmt --all -- --check` still reports repository-wide pre-existing formatting drift unrelated to this diff; no unrelated files were reformatted.

Closes #214
