### PR TITLE
docs: refresh project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,67 @@
+<p align="center">
+  <img src="./images/brand.png" alt="PoloDB" width="480" />
+</p>
 
-<img src="./images/brand.png" alt="" width="480" />
+<p align="center">
+  An embedded document database for Rust with a MongoDB-like API.
+</p>
 
-[![Crates.io](https://img.shields.io/crates/v/polodb_core.svg)](https://crates.io/crates/polodb_core)
-[![Discord](https://img.shields.io/discord/1061903499190865930)](https://discord.gg/NmGQyVx6hH)
-[![docs.rs](https://docs.rs/polodb_core/badge.svg)](https://docs.rs/polodb_core)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
+<p align="center">
+  <a href="https://github.com/PoloDB/PoloDB/actions/workflows/rust.yml"><img src="https://github.com/PoloDB/PoloDB/actions/workflows/rust.yml/badge.svg" alt="CI" /></a>
+  <a href="https://crates.io/crates/polodb_core"><img src="https://img.shields.io/crates/v/polodb_core.svg" alt="Crates.io" /></a>
+  <a href="https://docs.rs/polodb_core"><img src="https://docs.rs/polodb_core/badge.svg" alt="docs.rs" /></a>
+  <a href="https://github.com/PoloDB/PoloDB/releases/latest"><img src="https://img.shields.io/github/v/release/PoloDB/PoloDB" alt="GitHub release" /></a>
+  <a href="LICENSE.txt"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="Apache-2.0 license" /></a>
+</p>
 
-PoloDB is an embedded document database.
+PoloDB stores BSON documents locally and exposes familiar collection, query,
+update, index, aggregation, and transaction APIs. It can be used as an
+embedded Rust library or run as a standalone server with partial MongoDB wire
+protocol compatibility.
 
-| [Documentations](https://www.polodb.org/docs) |
+## Features
 
-# Introduction
+- Embedded, typed Rust API built around `serde` and BSON
+- MongoDB-like CRUD, query, update, index, and aggregation APIs
+- Explicit transactions and automatic per-operation transactions
+- Concurrent use through clonable database handles
+- RocksDB-backed persistent storage
+- Standalone server for supported MongoDB driver operations
+- Experimental Python bindings built from the same Rust core
 
-PoloDB is a library written in Rust
-that implements a lightweight [MongoDB](https://www.mongodb.com/).
+## Project status
 
-# Why
+The latest stable release is
+[v5.2.0](https://github.com/PoloDB/PoloDB/releases/tag/v5.2.0).
+See the [changelog](CHANGELOG.md) for release details.
 
-PoloDB aims to offer a modern alternative to SQLite, which is currently the almost exclusive option for client-side data storage.
-Although SQLite is an old and stable software, it lacks some modern features.
-That's why we developed PoloDB, which is NoSQL, supports multi-threading and multi-sessions,
-and retains the embedded and lightweight features of SQLite.
+PoloDB v5 uses RocksDB as its storage backend. A database path is a directory,
+not a single portable database file. The first build compiles the bundled
+RocksDB sources and can take several minutes.
 
-# Features
+Rust CI currently covers Ubuntu x64, Ubuntu ARM64, macOS, and Windows. Python
+bindings are tested on Python 3.12 through 3.14. Indexes, aggregation, the
+standalone server, and language bindings continue to evolve; test the behavior
+your application depends on before using PoloDB in production.
 
-- Simple and Lightweight
-  - can be embedded library or a standalone server
-- Easy to learn and use
-  - NoSQL
-  - MongoDB-like API
-- Cross-Platform
+## Installation
 
-# Quick start
+Add the embedded library and Serde to your project:
 
-PoloDB is easy to learn and use:
+```toml
+[dependencies]
+polodb_core = "5.2.0"
+serde = { version = "1", features = ["derive"] }
+```
+
+Building requires a Rust toolchain, a C/C++ build toolchain, and Clang/libclang
+for the bundled RocksDB bindings.
+
+## Quick start
 
 ```rust
-use polodb_core::Database;
-use serde::{Serialize, Deserialize};
+use polodb_core::{bson::doc, CollectionT, Database};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Book {
@@ -45,52 +69,64 @@ struct Book {
     author: String,
 }
 
-let db = Database::open_path(db_path)?;
-let collection = db.collection::<Book>("books");
-collection.insert_one(Book {
-    title: "The Three-Body Problem".to_string(),
-    author: "Liu Cixin".to_string(),
-})?;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let db = Database::open_path("./data/books")?;
+    let books = db.collection::<Book>("books");
+
+    books.insert_one(Book {
+        title: "The Three-Body Problem".to_string(),
+        author: "Liu Cixin".to_string(),
+    })?;
+
+    let book = books.find_one(doc! {
+        "author": "Liu Cixin",
+    })?;
+
+    println!("{book:?}");
+    Ok(())
+}
 ```
 
-# Packages
-  
-- polodb: The standalone server of PoloDB, which is compatible with MongoDB's wire protocol.
-- [polodb_core](https://crates.io/crates/polodb_core): The core library of PoloDB, which can be embedded in your application.
+See the [PoloDB documentation](https://www.polodb.org/docs) and
+[`polodb_core` API documentation](https://docs.rs/polodb_core) for queries,
+updates, indexes, aggregation, and transactions.
 
-# Platform
+## Standalone server
 
-Theoretically, PoloDB supports all platforms that the Rust compiler
-supports.
-But PoloDB is a personal project currently.
-Limited by my time, I have only compiled and tested on the following platforms:
+Install and start the server:
 
-- macOS Big Sur x64
-- Linux x64 (Tested on Fedora 32)
-- Windows 10 x64
+```console
+cargo install polodb --version 5.2.0
+polodb serve --path ./data/server --host 127.0.0.1 --port 27017
+```
 
-# Manual
+The server implements the subset of the MongoDB wire protocol used by its
+supported commands. It is not a drop-in replacement for a full MongoDB server.
 
-- [Documentations](https://www.polodb.org/docs)
-- [Rust](https://docs.rs/polodb_core)
+## Packages
 
-# Roadmap
+| Package | Status | Purpose |
+| --- | --- | --- |
+| [`polodb_core`](https://crates.io/crates/polodb_core) | Published | Embedded Rust database library |
+| [`polodb`](https://crates.io/crates/polodb) | Published | Standalone server and CLI |
+| [`py-polodb`](py-polodb/README.md) | Experimental | Python bindings developed in this repository |
 
-The features will be implemented one by one in order.
+Release binaries for the standalone server are published for macOS x64, Linux
+x64, and Windows x64 on the
+[GitHub Releases page](https://github.com/PoloDB/PoloDB/releases).
 
-- [x] Basic database API
-  - [x] CRUD
-  - [x] Transactions
-  - [x] Serde
-  - [x] Indexes(Alpha)
-  - [x] Aggregation(Alpha)
-- [x] Command line Tools
-- [ ] Platforms
-  - [x] MacOS
-  - [x] Linux
-  - [x] Windows
-  - [ ] iOS
-  - [ ] Android
-- [ ] Languages
-  - [ ] Python
-  - [ ] JavaScript
+## Roadmap and support
+
+Open work is tracked in [GitHub Issues](https://github.com/PoloDB/PoloDB/issues).
+Mobile SDKs, additional language bindings, encryption, multikey indexes, and
+alternative storage backends require further design and are not part of the
+current stable feature set.
+
+- [Documentation](https://www.polodb.org/docs)
+- [Rust API](https://docs.rs/polodb_core)
+- [Issues](https://github.com/PoloDB/PoloDB/issues)
+- [Discord](https://discord.gg/NmGQyVx6hH)
+
+## License
+
+PoloDB is licensed under the [Apache License 2.0](LICENSE.txt).


### PR DESCRIPTION
## Summary

- rewrite the README around the current v5.2.0 project state
- document RocksDB storage, build prerequisites, tested platforms, and compatibility boundaries
- replace the incomplete quick start with a compile-checked Rust example
- describe the Rust library, standalone server, and experimental Python bindings accurately
- fix the license link and add CI/release badges

## Why

The existing README still described old operating systems, listed Python as
unimplemented, omitted the RocksDB build and storage model, and included a Rust
example with an undefined path and a missing trait import.

## Impact

Documentation only. No runtime or public API behavior changes.

## Validation

- `git diff --check`
- verified all referenced local files exist
- `cargo test --locked --doc -p polodb_core` (6 passed)
- compiled the README quick-start example in an isolated crate with
  `cargo check --offline`
