### PR TITLE
fix(core): support nested range queries

### DIFF
--- a/src/polodb_core/tests/test_find.rs
+++ b/src/polodb_core/tests/test_find.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use polodb_core::{Result, CollectionT};
-use polodb_core::bson::{doc, Document};
+use polodb_core::bson::{doc, DateTime, Document};
 
 mod common;
 
@@ -108,6 +108,207 @@ fn test_find() {
         let one = result[0].clone();
         assert_eq!(one.get("content").unwrap().as_str().unwrap(), "3");
     });
+}
+
+#[test]
+fn test_nested_range_queries() {
+    let db = prepare_db("test-nested-range-queries").unwrap();
+    let collection = db.collection::<Document>("events");
+
+    collection.insert_many(vec![
+        doc! {
+            "_id": 1,
+            "metadata": {
+                "created_at": -1,
+            },
+        },
+        doc! {
+            "_id": 2,
+            "metadata": {
+                "created_at": 0,
+            },
+        },
+        doc! {
+            "_id": 3,
+            "metadata": {
+                "created_at": 10,
+            },
+        },
+        doc! {
+            "_id": 4,
+            "metadata": {},
+        },
+        doc! {
+            "_id": 5,
+            "metadata": "not a document",
+        },
+        doc! {
+            "_id": 6,
+            "metadata": {
+                "audit": {
+                    "created_at": 20,
+                },
+            },
+        },
+    ]).unwrap();
+
+    let cases = [
+        (
+            doc! {
+                "metadata.created_at": {
+                    "$gt": 0,
+                },
+            },
+            vec![3],
+        ),
+        (
+            doc! {
+                "metadata.created_at": {
+                    "$gte": 0,
+                },
+            },
+            vec![2, 3],
+        ),
+        (
+            doc! {
+                "metadata.created_at": {
+                    "$lt": 10,
+                },
+            },
+            vec![1, 2],
+        ),
+        (
+            doc! {
+                "metadata.created_at": {
+                    "$lte": 0,
+                },
+            },
+            vec![1, 2],
+        ),
+        (
+            doc! {
+                "metadata.created_at": {
+                    "$gte": 0,
+                    "$lt": 10,
+                },
+            },
+            vec![2],
+        ),
+        (
+            doc! {
+                "metadata.audit.created_at": {
+                    "$gte": 20,
+                },
+            },
+            vec![6],
+        ),
+    ];
+
+    for (filter, expected_ids) in cases {
+        let mut actual_ids = collection
+            .find(filter)
+            .run()
+            .unwrap()
+            .collect::<Result<Vec<Document>>>()
+            .unwrap()
+            .into_iter()
+            .map(|document| document.get_i32("_id").unwrap())
+            .collect::<Vec<_>>();
+        actual_ids.sort_unstable();
+        assert_eq!(actual_ids, expected_ids);
+    }
+}
+
+#[test]
+fn test_nested_datetime_range_query() {
+    let db = prepare_db("test-nested-datetime-range-query").unwrap();
+    let collection = db.collection::<Document>("events");
+
+    collection.insert_many(vec![
+        doc! {
+            "_id": 1,
+            "metadata": {
+                "created_at": DateTime::from_millis(-1),
+            },
+        },
+        doc! {
+            "_id": 2,
+            "metadata": {
+                "created_at": DateTime::from_millis(10),
+            },
+        },
+    ]).unwrap();
+
+    let result = collection
+        .find(doc! {
+            "metadata.created_at": {
+                "$gte": DateTime::from_millis(0),
+            },
+        })
+        .run()
+        .unwrap()
+        .collect::<Result<Vec<Document>>>()
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].get_i32("_id").unwrap(), 2);
+}
+
+#[test]
+fn test_nested_range_queries_in_update_and_delete() {
+    let db = prepare_db("test-nested-range-queries-in-update-and-delete").unwrap();
+    let collection = db.collection::<Document>("events");
+
+    collection.insert_many(vec![
+        doc! {
+            "_id": 1,
+            "metadata": {
+                "created_at": 1,
+            },
+            "status": "old",
+        },
+        doc! {
+            "_id": 2,
+            "metadata": {
+                "created_at": 20,
+            },
+            "status": "old",
+        },
+    ]).unwrap();
+
+    let update_result = collection.update_one(
+        doc! {
+            "metadata.created_at": {
+                "$gte": 20,
+            },
+        },
+        doc! {
+            "$set": {
+                "status": "new",
+            },
+        },
+    ).unwrap();
+
+    assert_eq!(update_result.matched_count, 1);
+    assert_eq!(update_result.modified_count, 1);
+    assert_eq!(
+        collection.find_one(doc! {
+            "_id": 2,
+        }).unwrap().unwrap().get_str("status").unwrap(),
+        "new",
+    );
+
+    let delete_result = collection.delete_one(doc! {
+        "metadata.created_at": {
+            "$lt": 10,
+        },
+    }).unwrap();
+
+    assert_eq!(delete_result.deleted_count, 1);
+    assert_eq!(collection.count_documents().unwrap(), 1);
+    assert!(collection.find_one(doc! {
+        "_id": 1,
+    }).unwrap().is_none());
 }
 
 #[test]

--- a/src/polodb_core/vm/codegen.rs
+++ b/src/polodb_core/vm/codegen.rs
@@ -583,14 +583,10 @@ impl Codegen {
         Ok(())
     }
 
-    fn recursively_get_field(&mut self, key: &str, get_field_failed_label: Label) -> usize {
-        let slices: Vec<&str> = key.split('.').collect();
-        for slice in &slices {
-            let str_ref: &str = slice;
-            let current_stat_id = self.push_static(str_ref.into());
-            self.emit_goto2(DbOp::GetField, current_stat_id, get_field_failed_label);
-        }
-        slices.len()
+    fn get_field(&mut self, key: &str, get_field_failed_label: Label) -> usize {
+        let key_static_id = self.push_static(key.into());
+        self.emit_goto2(DbOp::GetField, key_static_id, get_field_failed_label);
+        1
     }
 
     fn get_field_or_null(&mut self, key: &str) -> usize {
@@ -663,7 +659,7 @@ impl Codegen {
     ) -> Result<()> {
         match sub_key {
             "$eq" => {
-                let field_size = self.recursively_get_field(key, not_found_label);
+                let field_size = self.get_field(key, not_found_label);
 
                 let stat_val_id = self.push_static(sub_value.clone());
                 self.emit_push_value(stat_val_id);
@@ -677,7 +673,7 @@ impl Codegen {
             }
 
             "$gt" => {
-                let field_size = self.recursively_get_field(key, not_found_label);
+                let field_size = self.get_field(key, not_found_label);
 
                 let stat_val_id = self.push_static(sub_value.clone());
                 self.emit_push_value(stat_val_id);
@@ -690,7 +686,7 @@ impl Codegen {
             }
 
             "$gte" => {
-                let field_size = self.recursively_get_field(key, not_found_label);
+                let field_size = self.get_field(key, not_found_label);
 
                 let stat_val_id = self.push_static(sub_value.clone());
                 self.emit_push_value(stat_val_id);
@@ -734,7 +730,7 @@ impl Codegen {
             }
 
             "$lt" => {
-                let field_size = self.recursively_get_field(key, not_found_label);
+                let field_size = self.get_field(key, not_found_label);
 
                 let stat_val_id = self.push_static(sub_value.clone());
                 self.emit_push_value(stat_val_id);
@@ -747,7 +743,7 @@ impl Codegen {
             }
 
             "$lte" => {
-                let field_size = self.recursively_get_field(key, not_found_label);
+                let field_size = self.get_field(key, not_found_label);
 
                 let stat_val_id = self.push_static(sub_value.clone());
                 self.emit_push_value(stat_val_id);
@@ -761,7 +757,7 @@ impl Codegen {
             }
 
             "$ne" => {
-                let field_size = self.recursively_get_field(key, not_found_label);
+                let field_size = self.get_field(key, not_found_label);
 
                 let stat_val_id = self.push_static(sub_value.clone());
                 self.emit_push_value(stat_val_id);
@@ -800,7 +796,7 @@ impl Codegen {
                     }
                 };
 
-                let field_size = self.recursively_get_field(key, not_found_label);
+                let field_size = self.get_field(key, not_found_label);
                 self.emit(DbOp::ArraySize);
 
                 let expect_size_stat_id = self.push_static(Bson::from(expected_size));
@@ -825,7 +821,7 @@ impl Codegen {
                     }
                 }
 
-                let field_size = self.recursively_get_field(key, not_found_label);
+                let field_size = self.get_field(key, not_found_label);
 
                 let stat_val_id = self.push_static(sub_value.clone());
                 self.emit_push_value(stat_val_id);


### PR DESCRIPTION
## Summary

- compile dotted query fields as a single `GetField` lookup
- keep missing paths and non-document intermediate values as non-matches
- add regression coverage for nested numeric and DateTime ranges in find, update, and delete operations

## Root cause

Range operators split dotted field names into separate `GetField` instructions. The first lookup therefore asked for the intermediate document itself, but the existing field resolver only returned terminal scalar values. The query failed before it could reach the nested field.

Passing the full dotted path to the existing resolver fixes the lookup and reduces the VM stack cleanup to one field value.

## Test plan

- `cargo test -p polodb_core --test test_find --offline`
- `cargo test -p polodb_core --offline`
- `cargo test --locked --release --verbose --workspace --exclude py-binding-polodb --offline`

Closes #202
