### PR TITLE
fix(core): reject duplicate _id inserts

### DIFF
--- a/src/polodb_core/db/db_inner.rs
+++ b/src/polodb_core/db/db_inner.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use bson::{Bson, Document};
 use serde::Serialize;
 use super::db::Result;
-use crate::errors::Error;
+use crate::errors::{DuplicateKeyError, Error};
 use crate::options::UpdateOptions;
 use crate::Config;
 use crate::vm::SubProgram;
@@ -430,6 +430,15 @@ impl DatabaseInner {
             &Bson::String(col_spec._id.clone()),
             pkey,
         ])?;
+
+        if txn.rocksdb_txn.get(stacked_key.as_ref())?.is_some() {
+            return Err(DuplicateKeyError {
+                name: "_id_".to_string(),
+                key: pkey.to_string(),
+                ns: col_spec.name().to_string(),
+            }
+            .into());
+        }
 
         let doc_buf = bson::to_vec(&doc)?;
 

--- a/src/polodb_core/tests/test_insert.rs
+++ b/src/polodb_core/tests/test_insert.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 use bson::Document;
 use bson::spec::ElementType;
 use serde::{Deserialize, Serialize};
-use polodb_core::{Database, Result, CollectionT};
+use polodb_core::{CollectionT, Database, Error, Result};
 use polodb_core::bson::{doc, Bson};
 
 mod common;
@@ -259,6 +259,65 @@ fn test_insert_different_types_as_key() {
 
     assert_eq!(result[0].as_ref().unwrap().get("_id").unwrap().element_type(), ElementType::String);
     assert_eq!(result[1].as_ref().unwrap().get("_id").unwrap().element_type(), ElementType::Int32);
+}
+
+#[test]
+fn test_insert_one_duplicate_id_preserves_original_document() {
+    let db = prepare_db("test-insert-one-duplicate-id").unwrap();
+    let collection = db.collection::<Document>("test");
+
+    collection.insert_one(doc! {
+        "_id": "duplicate",
+        "value": "original",
+    }).unwrap();
+
+    let error = collection.insert_one(doc! {
+        "_id": "duplicate",
+        "value": "replacement",
+    }).unwrap_err();
+
+    assert!(matches!(error, Error::DuplicateKey(_)));
+    assert_eq!(collection.count_documents().unwrap(), 1);
+    assert_eq!(collection.find_one(doc! {
+        "_id": "duplicate",
+    }).unwrap().unwrap(), doc! {
+        "_id": "duplicate",
+        "value": "original",
+    });
+}
+
+#[test]
+fn test_insert_many_duplicate_id_rolls_back_all_documents() {
+    let db = prepare_db("test-insert-many-duplicate-id").unwrap();
+    let collection = db.collection::<Document>("test");
+
+    collection.insert_one(doc! {
+        "_id": "existing",
+        "value": "original",
+    }).unwrap();
+
+    let error = collection.insert_many(vec![
+        doc! {
+            "_id": "new",
+            "value": "must be rolled back",
+        },
+        doc! {
+            "_id": "existing",
+            "value": "replacement",
+        },
+    ]).unwrap_err();
+
+    assert!(matches!(error, Error::DuplicateKey(_)));
+    assert_eq!(collection.count_documents().unwrap(), 1);
+    assert!(collection.find_one(doc! {
+        "_id": "new",
+    }).unwrap().is_none());
+    assert_eq!(collection.find_one(doc! {
+        "_id": "existing",
+    }).unwrap().unwrap(), doc! {
+        "_id": "existing",
+        "value": "original",
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- reject inserts whose `_id` already exists in the collection
- return the existing duplicate-key error shape using the `_id_` index name
- preserve the original document instead of silently overwriting it
- keep `insert_many` atomic when a later item has a duplicate `_id`

## Why

MongoDB treats `_id` as a unique primary key. PoloDB previously called `put` directly and replaced an existing document with the same `_id`.

## Tests

- duplicate `insert_one` returns `Error::DuplicateKey` and preserves the original document
- duplicate inside `insert_many` rolls back earlier inserts in the same operation
- `git diff --check`
- `cargo metadata --no-deps`

Full cross-platform tests are delegated to GitHub Actions because the bundled RocksDB debug build exceeds the local runner timeout.