### PR TITLE
fix(core): only upsert when no document matches

### DIFF
--- a/src/polodb_core/db/db_inner.rs
+++ b/src/polodb_core/db/db_inner.rs
@@ -589,7 +589,7 @@ impl DatabaseInner {
             },
             None => UpdateResult::default(),
         };
-        if options.is_upsert() && result.modified_count == 0 {
+        if options.is_upsert() && result.matched_count == 0 {
             self.upsert(col_name, query, update, txn)?;
         }
 

--- a/src/polodb_core/tests/test_update.rs
+++ b/src/polodb_core/tests/test_update.rs
@@ -300,3 +300,28 @@ fn test_upsert() {
     // assert_eq!(hobbies.len(), 1);
     // assert_eq!(hobbies[0].as_str().unwrap(), "reading");
 }
+
+#[test]
+fn test_upsert_does_not_insert_when_update_is_noop() {
+    let db = prepare_db("test-upsert-noop").unwrap();
+    let col = db.collection::<Document>("test");
+    let original = doc! {
+        "_id": 1,
+        "name": "John",
+        "age": 30,
+    };
+    col.insert_one(original.clone()).unwrap();
+
+    let update_result = col
+        .update_one_with_options(
+            doc! { "name": "John" },
+            doc! { "$set": {} },
+            UpdateOptions::builder().upsert(true).build(),
+        )
+        .unwrap();
+
+    assert_eq!(update_result.matched_count, 1);
+    assert_eq!(update_result.modified_count, 0);
+    assert_eq!(col.count_documents().unwrap(), 1);
+    assert_eq!(col.find_one(doc! { "_id": 1 }).unwrap(), Some(original));
+}


### PR DESCRIPTION
## Summary

- trigger upsert only when `matched_count == 0`
- do not insert when an existing document matched but the update was a no-op
- add a regression test that verifies the original document remains unchanged

## Why

MongoDB upsert semantics depend on whether a document matched, not whether it was modified. Using `modified_count == 0` can enter the insert path for a matched no-op update.

## Tests

- matched empty `$set` with `upsert: true` reports one match, zero modifications, and keeps exactly one unchanged document
- existing unmatched-upsert coverage remains in place
- `git diff --check`
- `cargo metadata --no-deps`

Full cross-platform tests are delegated to GitHub Actions because the bundled RocksDB debug build exceeds the local runner timeout.