### PR TITLE
fix(core): support dotted paths in update operators

### DIFF
--- a/src/polodb_core/tests/test_update.rs
+++ b/src/polodb_core/tests/test_update.rs
@@ -325,3 +325,149 @@ fn test_upsert_does_not_insert_when_update_is_noop() {
     assert_eq!(col.count_documents().unwrap(), 1);
     assert_eq!(col.find_one(doc! { "_id": 1 }).unwrap(), Some(original));
 }
+
+#[test]
+fn test_update_dotted_paths() {
+    let db = prepare_db("test-update-dotted-paths").unwrap();
+    let col = db.collection::<Document>("test");
+    col.insert_one(doc! {
+        "_id": 1,
+        "profile": {
+            "name": "Vincent",
+            "stats": { "visits": 2 },
+            "address": { "city": "London", "zip": "E1" },
+            "tags": ["rust"],
+        },
+    })
+    .unwrap();
+
+    let result = col
+        .update_one(
+            doc! { "_id": 1 },
+            doc! {
+                "$set": {
+                    "profile.name": "Steve",
+                    "profile.preferences.theme": "dark",
+                },
+                "$unset": { "profile.address.city": "" },
+                "$inc": { "profile.stats.visits": 3 },
+                "$push": { "profile.tags": "database" },
+            },
+        )
+        .unwrap();
+    assert_eq!(result.modified_count, 1);
+
+    let actual = col.find_one(doc! { "_id": 1 }).unwrap().unwrap();
+    let profile = actual.get_document("profile").unwrap();
+    assert_eq!(profile.get_str("name").unwrap(), "Steve");
+    assert_eq!(
+        profile
+            .get_document("preferences")
+            .unwrap()
+            .get_str("theme")
+            .unwrap(),
+        "dark"
+    );
+    assert_eq!(
+        profile
+            .get_document("stats")
+            .unwrap()
+            .get_i32("visits")
+            .unwrap(),
+        5
+    );
+    let address = profile.get_document("address").unwrap();
+    assert!(!address.contains_key("city"));
+    assert_eq!(address.get_str("zip").unwrap(), "E1");
+    assert_eq!(
+        profile.get_array("tags").unwrap(),
+        &vec!["rust".into(), "database".into()]
+    );
+}
+
+#[test]
+fn test_dotted_update_rejects_non_document_intermediate_and_rolls_back() {
+    let db = prepare_db("test-update-dotted-non-document").unwrap();
+    let col = db.collection::<Document>("test");
+    let original = doc! {
+        "_id": 1,
+        "status": "original",
+        "profile": "not a document",
+    };
+    col.insert_one(original.clone()).unwrap();
+
+    let result = col.update_one(
+        doc! { "_id": 1 },
+        doc! { "$set": {
+            "status": "changed",
+            "profile.name": "Steve",
+        } },
+    );
+    assert!(result.is_err());
+    assert_eq!(col.find_one(doc! { "_id": 1 }).unwrap().unwrap(), original);
+}
+
+#[test]
+fn test_dotted_update_rejects_primary_key_descendants_and_conflicts() {
+    let db = prepare_db("test-update-dotted-invalid-paths").unwrap();
+    let col = db.collection::<Document>("test");
+    col.insert_one(doc! { "_id": 1, "profile": {} }).unwrap();
+
+    assert!(col
+        .update_one(
+            doc! { "_id": 1 },
+            doc! { "$set": { "_id.value": 2 } },
+        )
+        .is_err());
+    assert!(col
+        .update_one(
+            doc! { "_id": 1 },
+            doc! { "$set": { "profile": {}, "profile.name": "Steve" } },
+        )
+        .is_err());
+}
+
+#[test]
+fn test_remaining_update_operators_support_dotted_paths() {
+    let db = prepare_db("test-update-remaining-dotted-paths").unwrap();
+    let col = db.collection::<Document>("test");
+    col.insert_one(doc! {
+        "_id": 1,
+        "profile": {
+            "score": 2,
+            "minimum": 5,
+            "maximum": 5,
+            "queue": [1, 2],
+            "old_name": "Vincent",
+        },
+    })
+    .unwrap();
+
+    col.update_one(
+        doc! { "_id": 1 },
+        doc! {
+            "$mul": { "profile.score": 3 },
+            "$min": { "profile.minimum": 2 },
+            "$max": { "profile.maximum": 8 },
+            "$pop": { "profile.queue": 1 },
+            "$rename": { "profile.old_name": "archive.name" },
+        },
+    )
+    .unwrap();
+
+    let actual = col.find_one(doc! { "_id": 1 }).unwrap().unwrap();
+    let profile = actual.get_document("profile").unwrap();
+    assert_eq!(profile.get_i32("score").unwrap(), 6);
+    assert_eq!(profile.get_i32("minimum").unwrap(), 2);
+    assert_eq!(profile.get_i32("maximum").unwrap(), 8);
+    assert_eq!(profile.get_array("queue").unwrap(), &vec![1.into()]);
+    assert!(!profile.contains_key("old_name"));
+    assert_eq!(
+        actual
+            .get_document("archive")
+            .unwrap()
+            .get_str("name")
+            .unwrap(),
+        "Vincent"
+    );
+}

--- a/src/polodb_core/tests/test_update.rs
+++ b/src/polodb_core/tests/test_update.rs
@@ -14,7 +14,7 @@
 
 use polodb_core::options::UpdateOptions;
 use polodb_core::{CollectionT, Database, Result};
-use polodb_core::bson::{Document, doc};
+use polodb_core::bson::{Bson, Decimal128, Document, doc};
 
 mod common;
 
@@ -411,7 +411,14 @@ fn test_dotted_update_rejects_non_document_intermediate_and_rolls_back() {
 fn test_dotted_update_rejects_primary_key_descendants_and_conflicts() {
     let db = prepare_db("test-update-dotted-invalid-paths").unwrap();
     let col = db.collection::<Document>("test");
-    col.insert_one(doc! { "_id": 1, "profile": {} }).unwrap();
+    let original = doc! {
+        "_id": 1,
+        "profile": {
+            "name": "Vincent",
+            "visits": 1,
+        },
+    };
+    col.insert_one(original.clone()).unwrap();
 
     assert!(col
         .update_one(
@@ -425,6 +432,39 @@ fn test_dotted_update_rejects_primary_key_descendants_and_conflicts() {
             doc! { "$set": { "profile": {}, "profile.name": "Steve" } },
         )
         .is_err());
+    assert!(col
+        .update_one(
+            doc! { "_id": 1 },
+            doc! {
+                "$set": { "profile": {} },
+                "$inc": { "profile.visits": 1 },
+            },
+        )
+        .is_err());
+    assert!(col
+        .update_one(
+            doc! { "_id": 1 },
+            doc! { "$rename": { "profile": "profile.archive" } },
+        )
+        .is_err());
+    assert!(col
+        .update_one(
+            doc! { "_id": 1 },
+            doc! { "$rename": { "profile.name": "profile" } },
+        )
+        .is_err());
+    assert!(col
+        .update_one(
+            doc! { "_id": 1 },
+            doc! {
+                "$rename": {
+                    "profile.name": "archive.value",
+                    "profile.visits": "archive.value",
+                },
+            },
+        )
+        .is_err());
+    assert_eq!(col.find_one(doc! { "_id": 1 }).unwrap(), Some(original));
 }
 
 #[test]
@@ -469,5 +509,35 @@ fn test_remaining_update_operators_support_dotted_paths() {
             .get_str("name")
             .unwrap(),
         "Vincent"
+    );
+}
+
+#[test]
+fn test_dotted_mul_creates_typed_zero_for_missing_fields() {
+    let db = prepare_db("test-update-dotted-mul-missing-fields").unwrap();
+    let col = db.collection::<Document>("test");
+    col.insert_one(doc! { "_id": 1 }).unwrap();
+
+    col.update_one(
+        doc! { "_id": 1 },
+        doc! {
+            "$mul": {
+                "stats.int32": 3,
+                "stats.int64": 3_i64,
+                "stats.double": 3.0,
+                "stats.decimal": Bson::Decimal128("3".parse::<Decimal128>().unwrap()),
+            },
+        },
+    )
+    .unwrap();
+
+    let actual = col.find_one(doc! { "_id": 1 }).unwrap().unwrap();
+    let stats = actual.get_document("stats").unwrap();
+    assert_eq!(stats.get("int32"), Some(&Bson::Int32(0)));
+    assert_eq!(stats.get("int64"), Some(&Bson::Int64(0)));
+    assert_eq!(stats.get("double"), Some(&Bson::Double(0.0)));
+    assert_eq!(
+        stats.get("decimal"),
+        Some(&Bson::Decimal128("0".parse::<Decimal128>().unwrap())),
     );
 }

--- a/src/polodb_core/tests/test_update.rs
+++ b/src/polodb_core/tests/test_update.rs
@@ -460,7 +460,7 @@ fn test_remaining_update_operators_support_dotted_paths() {
     assert_eq!(profile.get_i32("score").unwrap(), 6);
     assert_eq!(profile.get_i32("minimum").unwrap(), 2);
     assert_eq!(profile.get_i32("maximum").unwrap(), 8);
-    assert_eq!(profile.get_array("queue").unwrap(), &vec![1.into()]);
+    assert_eq!(profile.get_array("queue").unwrap().len(), 1);
     assert!(!profile.contains_key("old_name"));
     assert_eq!(
         actual

--- a/src/polodb_core/vm/codegen.rs
+++ b/src/polodb_core/vm/codegen.rs
@@ -1094,6 +1094,8 @@ impl Codegen {
     }
 
     pub(super) fn emit_update_operation(&mut self, update: &Document) -> Result<()> {
+        <dyn UpdateOperator>::validate_update_document(update)?;
+
         self.emit(DbOp::IncR2);
         self.emit(DbOp::StoreR0_2);
         self.emit_u8(0);

--- a/src/polodb_core/vm/subprogram.rs
+++ b/src/polodb_core/vm/subprogram.rs
@@ -1386,13 +1386,13 @@ mod tests {
                 "age": 1,
             },
             "$mul": doc! {
-                "age": 3,
+                "score": 3,
             },
             "$min": doc! {
-                "age": 100,
+                "rank": 100,
             },
             "$unset": doc! {
-                "age": "",
+                "status": "",
             },
             "$rename": doc! {
                 "hello1": "hello2",

--- a/src/polodb_core/vm/update_operators/document_path.rs
+++ b/src/polodb_core/vm/update_operators/document_path.rs
@@ -1,0 +1,125 @@
+// Copyright 2024 Vincent Chan
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bson::{Bson, Document};
+
+use crate::errors::FieldTypeUnexpectedStruct;
+use crate::Result;
+
+fn split_path(path: &str) -> Result<Vec<&str>> {
+    let parts: Vec<_> = path.split('.').collect();
+    if parts.iter().any(|part| part.is_empty()) {
+        return Err(crate::Error::ValidationError(format!(
+            "update path '{path}' contains an empty field name"
+        )));
+    }
+    Ok(parts)
+}
+
+fn non_document_path_error(path: &str, value: &Bson) -> crate::Error {
+    FieldTypeUnexpectedStruct {
+        field_name: path.into(),
+        expected_ty: "Document".into(),
+        actual_ty: value.to_string(),
+    }
+    .into()
+}
+
+pub(super) fn validate_update_path(path: &str) -> Result<()> {
+    let parts = split_path(path)?;
+    if parts.first() == Some(&"_id") {
+        return Err(crate::Error::UnableToUpdatePrimaryKey);
+    }
+    Ok(())
+}
+
+pub(super) fn paths_conflict(left: &str, right: &str) -> bool {
+    left == right
+        || left
+            .strip_prefix(right)
+            .is_some_and(|suffix| suffix.starts_with('.'))
+        || right
+            .strip_prefix(left)
+            .is_some_and(|suffix| suffix.starts_with('.'))
+}
+
+pub(super) fn get_path<'a>(doc: &'a Document, path: &str) -> Result<Option<&'a Bson>> {
+    let parts = split_path(path)?;
+    let mut current = doc;
+
+    for (index, part) in parts.iter().enumerate() {
+        let value = match current.get(*part) {
+            Some(value) => value,
+            None => return Ok(None),
+        };
+        if index == parts.len() - 1 {
+            return Ok(Some(value));
+        }
+        current = value
+            .as_document()
+            .ok_or_else(|| non_document_path_error(path, value))?;
+    }
+
+    unreachable!("split_path always returns at least one component")
+}
+
+fn parent_mut<'a>(
+    doc: &'a mut Document,
+    path: &str,
+    create: bool,
+) -> Result<(&'a mut Document, String)> {
+    let parts = split_path(path)?;
+    let (field, parents) = parts.split_last().unwrap();
+    let mut current = doc;
+
+    for part in parents {
+        if !current.contains_key(*part) {
+            if !create {
+                return Ok((current, field.to_string()));
+            }
+            current.insert(*part, Bson::Document(Document::new()));
+        }
+
+        let value = current.get_mut(*part).unwrap();
+        current = match value {
+            Bson::Document(document) => document,
+            other => return Err(non_document_path_error(path, other)),
+        };
+    }
+
+    Ok((current, field.to_string()))
+}
+
+pub(super) fn set_path(doc: &mut Document, path: &str, value: Bson) -> Result<Option<Bson>> {
+    let (parent, field) = parent_mut(doc, path, true)?;
+    Ok(parent.insert(field, value))
+}
+
+pub(super) fn remove_path(doc: &mut Document, path: &str) -> Result<Option<Bson>> {
+    if get_path(doc, path)?.is_none() {
+        return Ok(None);
+    }
+    let (parent, field) = parent_mut(doc, path, false)?;
+    Ok(parent.remove(&field))
+}
+
+pub(super) fn rename_path(doc: &mut Document, source: &str, destination: &str) -> Result<bool> {
+    let mut updated = doc.clone();
+    let Some(value) = remove_path(&mut updated, source)? else {
+        return Ok(false);
+    };
+    set_path(&mut updated, destination, value)?;
+    *doc = updated;
+    Ok(true)
+}

--- a/src/polodb_core/vm/update_operators/document_path.rs
+++ b/src/polodb_core/vm/update_operators/document_path.rs
@@ -54,6 +54,24 @@ pub(super) fn paths_conflict(left: &str, right: &str) -> bool {
             .is_some_and(|suffix| suffix.starts_with('.'))
 }
 
+pub(super) fn validate_update_paths<'a>(
+    paths: impl IntoIterator<Item = &'a str>,
+) -> Result<()> {
+    let mut validated_paths: Vec<&'a str> = Vec::new();
+    for path in paths {
+        validate_update_path(path)?;
+        for other in &validated_paths {
+            if paths_conflict(path, other) {
+                return Err(crate::Error::ValidationError(format!(
+                    "conflicting update paths '{other}' and '{path}'"
+                )));
+            }
+        }
+        validated_paths.push(path);
+    }
+    Ok(())
+}
+
 pub(super) fn get_path<'a>(doc: &'a Document, path: &str) -> Result<Option<&'a Bson>> {
     let parts = split_path(path)?;
     let mut current = doc;

--- a/src/polodb_core/vm/update_operators/inc_operator.rs
+++ b/src/polodb_core/vm/update_operators/inc_operator.rs
@@ -1,5 +1,6 @@
 use bson::{Bson, Document};
 use crate::vm::update_operators::{UpdateOperator, UpdateResult};
+use crate::vm::update_operators::document_path::{get_path, set_path};
 use crate::{Error, Result};
 use crate::errors::CannotApplyOperationForTypes;
 
@@ -42,20 +43,18 @@ impl IncOperator {
     }
 
     fn inc_field(doc: &mut Document, key: &str, value: Bson) -> Result<()> {
-        match doc.get(key) {
+        let result = match get_path(doc, key)? {
             Some(Bson::Null) => {
                 return Err(Error::IncrementNullField);
             }
 
             Some(original_value) => {
-                let result = IncOperator::inc_numeric(key, original_value, &value)?;
-                doc.insert::<String, Bson>(key.into(), result);
+                IncOperator::inc_numeric(key, original_value, &value)?
             }
 
-            None => {
-                doc.insert::<String, Bson>(key.into(), value);
-            }
-        }
+            None => value,
+        };
+        set_path(doc, key, result)?;
         Ok(())
     }
 

--- a/src/polodb_core/vm/update_operators/max_operator.rs
+++ b/src/polodb_core/vm/update_operators/max_operator.rs
@@ -2,6 +2,7 @@ use bson::{Bson, Document};
 use crate::Result;
 use crate::vm::op::{generic_cmp, DbOp};
 use crate::vm::update_operators::{UpdateOperator, UpdateResult};
+use crate::vm::update_operators::document_path::{get_path, set_path};
 
 pub(crate) struct MaxOperator {
     doc: Document,
@@ -28,10 +29,10 @@ impl UpdateOperator for MaxOperator {
 
         let mut updated = false;
         for (k, v) in self.doc.iter() {
-            let current_val = doc.get(k).unwrap_or(&Bson::Null);
+            let current_val = get_path(doc, k)?.unwrap_or(&Bson::Null);
             let cmp = generic_cmp(DbOp::Greater, v, current_val)?;
             if cmp {
-                doc.insert(k.clone(), v.clone());
+                set_path(doc, k, v.clone())?;
                 updated = true;
             }
         }

--- a/src/polodb_core/vm/update_operators/min_operator.rs
+++ b/src/polodb_core/vm/update_operators/min_operator.rs
@@ -2,6 +2,7 @@ use bson::{Bson, Document};
 use crate::Result;
 use crate::vm::op::{generic_cmp, DbOp};
 use crate::vm::update_operators::{UpdateOperator, UpdateResult};
+use crate::vm::update_operators::document_path::{get_path, set_path};
 
 pub(crate) struct MinOperator {
     doc: Document,
@@ -28,10 +29,10 @@ impl UpdateOperator for MinOperator {
 
         let mut updated = false;
         for (k, v) in self.doc.iter() {
-            let current_val = doc.get(k).unwrap_or(&Bson::Null);
+            let current_val = get_path(doc, k)?.unwrap_or(&Bson::Null);
             let cmp = generic_cmp(DbOp::Less, v, current_val)?;
             if cmp {
-                doc.insert(k.clone(), v.clone());
+                set_path(doc, k, v.clone())?;
                 updated = true;
             }
         }

--- a/src/polodb_core/vm/update_operators/mod.rs
+++ b/src/polodb_core/vm/update_operators/mod.rs
@@ -26,18 +26,37 @@ pub(crate) trait UpdateOperator {
 impl dyn UpdateOperator {
 
     pub(crate) fn validate_key(doc: &Document) -> Result<()> {
-        let keys: Vec<_> = doc.keys().collect();
-        for (index, k) in keys.iter().enumerate() {
-            document_path::validate_update_path(k)?;
-            for other in keys.iter().skip(index + 1) {
-                if document_path::paths_conflict(k, other) {
-                    return Err(crate::Error::ValidationError(format!(
-                        "conflicting update paths '{k}' and '{other}'"
-                    )));
-                }
+        document_path::validate_update_paths(doc.keys().map(String::as_str))
+    }
+
+    pub(crate) fn validate_update_document(update: &Document) -> Result<()> {
+        let mut paths = Vec::new();
+        for (operator, value) in update {
+            if !matches!(
+                operator.as_str(),
+                "$inc"
+                    | "$set"
+                    | "$max"
+                    | "$min"
+                    | "$mul"
+                    | "$rename"
+                    | "$unset"
+                    | "$push"
+                    | "$pop"
+            ) {
+                continue;
+            }
+
+            let Some(fields) = value.as_document() else {
+                continue;
+            };
+            paths.extend(fields.keys().map(String::as_str));
+
+            if operator == "$rename" {
+                paths.extend(fields.values().filter_map(Bson::as_str));
             }
         }
-        Ok(())
+        document_path::validate_update_paths(paths)
     }
 
 }

--- a/src/polodb_core/vm/update_operators/mod.rs
+++ b/src/polodb_core/vm/update_operators/mod.rs
@@ -1,3 +1,4 @@
+mod document_path;
 mod set_operator;
 mod inc_operator;
 mod mul_operator;
@@ -25,9 +26,15 @@ pub(crate) trait UpdateOperator {
 impl dyn UpdateOperator {
 
     pub(crate) fn validate_key(doc: &Document) -> Result<()> {
-        for (k, _) in doc.iter() {
-            if k == "_id" {
-                return Err(crate::Error::UnableToUpdatePrimaryKey);
+        let keys: Vec<_> = doc.keys().collect();
+        for (index, k) in keys.iter().enumerate() {
+            document_path::validate_update_path(k)?;
+            for other in keys.iter().skip(index + 1) {
+                if document_path::paths_conflict(k, other) {
+                    return Err(crate::Error::ValidationError(format!(
+                        "conflicting update paths '{k}' and '{other}'"
+                    )));
+                }
             }
         }
         Ok(())

--- a/src/polodb_core/vm/update_operators/mul_operator.rs
+++ b/src/polodb_core/vm/update_operators/mul_operator.rs
@@ -48,7 +48,23 @@ impl MulOperator {
                 MulOperator::mul_numeric(key, original_value, &value)?
             }
 
-            None => value,
+            None => match value {
+                Bson::Int32(_) => Bson::Int32(0),
+                Bson::Int64(_) => Bson::Int64(0),
+                Bson::Double(_) => Bson::Double(0.0),
+                Bson::Decimal128(_) => Bson::Decimal128(
+                    "0".parse().expect("zero is a valid Decimal128"),
+                ),
+                _ => {
+                    return Err(CannotApplyOperationForTypes {
+                        op_name: "$mul".into(),
+                        field_name: key.into(),
+                        field_type: "missing".into(),
+                        target_type: value.to_string(),
+                    }
+                    .into());
+                }
+            },
         };
         set_path(doc, key, new_value)?;
         Ok(())

--- a/src/polodb_core/vm/update_operators/mul_operator.rs
+++ b/src/polodb_core/vm/update_operators/mul_operator.rs
@@ -1,6 +1,7 @@
 use bson::{Bson, Document};
 use crate::errors::CannotApplyOperationForTypes;
 use crate::vm::update_operators::{UpdateOperator, UpdateResult};
+use crate::vm::update_operators::document_path::{get_path, set_path};
 use crate::Result;
 
 pub(crate) struct MulOperator {
@@ -42,16 +43,14 @@ impl MulOperator {
     }
 
     fn mul_field(doc: &mut Document, key: &str, value: Bson) -> Result<()> {
-        match doc.get(key) {
+        let new_value = match get_path(doc, key)? {
             Some(original_value) => {
-                let new_value = MulOperator::mul_numeric(key, original_value, &value)?;
-                doc.insert::<String, Bson>(key.into(), new_value);
+                MulOperator::mul_numeric(key, original_value, &value)?
             }
 
-            None => {
-                doc.insert::<String, Bson>(key.into(), value);
-            }
-        }
+            None => value,
+        };
+        set_path(doc, key, new_value)?;
         Ok(())
     }
 

--- a/src/polodb_core/vm/update_operators/pop_operator.rs
+++ b/src/polodb_core/vm/update_operators/pop_operator.rs
@@ -3,6 +3,7 @@ use indexmap::IndexMap;
 use crate::{Result, Error};
 use crate::errors::mk_invalid_query_field;
 use crate::vm::update_operators::{UpdateOperator, UpdateResult};
+use crate::vm::update_operators::document_path::{get_path, set_path};
 
 pub(crate) struct PopOperator {
     pop_map: IndexMap<String, bool>,
@@ -11,6 +12,7 @@ pub(crate) struct PopOperator {
 impl PopOperator {
 
     pub fn compile(doc: Document, name: String, path: String) -> Result<PopOperator> {
+        <dyn UpdateOperator>::validate_key(&doc)?;
         let mut pop_map = IndexMap::new();
         for (key, value) in doc.iter() {
             let num = match value {
@@ -53,8 +55,8 @@ impl UpdateOperator for PopOperator {
 
         let mut updated = false;
         for (k, is_first) in self.pop_map.iter() {
-            let target = doc.get(k).unwrap_or(&Bson::Null);
-            let result = match target.clone() {
+            let target = get_path(doc, k)?.cloned().unwrap_or(Bson::Null);
+            let result = match target {
                 Bson::Array(mut arr) => {
                     if arr.is_empty() {
                         continue;
@@ -76,7 +78,7 @@ impl UpdateOperator for PopOperator {
                     )))
                 }
             };
-            doc.insert(k.clone(), result);
+            set_path(doc, k, result)?;
             updated = true;
         }
 

--- a/src/polodb_core/vm/update_operators/push_operator.rs
+++ b/src/polodb_core/vm/update_operators/push_operator.rs
@@ -1,5 +1,6 @@
 use bson::{Bson, Document};
 use crate::vm::update_operators::{UpdateOperator, UpdateResult};
+use crate::vm::update_operators::document_path::{get_path, set_path};
 use crate::Result;
 use crate::errors::CannotApplyOperationForTypes;
 
@@ -29,7 +30,7 @@ impl UpdateOperator for PushOperator {
 
         let mut updated = false;
         for (k, v) in self.doc.iter() {
-            let target = doc.get(k).unwrap_or(&Bson::Null);
+            let target = get_path(doc, k)?.cloned().unwrap_or(Bson::Null);
             let result = match target.clone() {
                 Bson::Array(mut arr) => {
                     arr.push(v.clone());
@@ -48,7 +49,7 @@ impl UpdateOperator for PushOperator {
                         .into());
                 }
             };
-            doc.insert(k.clone(), result);
+            set_path(doc, k, result)?;
             updated = true;
         }
 

--- a/src/polodb_core/vm/update_operators/rename_operator.rs
+++ b/src/polodb_core/vm/update_operators/rename_operator.rs
@@ -1,51 +1,35 @@
-use bson::{Bson, Document};
 use crate::errors::FieldTypeUnexpectedStruct;
+use crate::vm::update_operators::document_path::{rename_path, validate_update_path};
 use crate::vm::update_operators::{UpdateOperator, UpdateResult};
 use crate::Result;
+use bson::{Bson, Document};
 
 pub(crate) struct RenameOperator {
-    doc: Document
+    doc: Document,
 }
 
 impl RenameOperator {
-
     pub fn compile(doc: Document) -> Result<RenameOperator> {
+        <dyn UpdateOperator>::validate_key(&doc)?;
         for (key, value) in doc.iter() {
-            let _new_name = match value {
+            let new_name = match value {
                 Bson::String(new_name) => new_name.as_str(),
                 t => {
-                    let name = format!("{}", t);
                     return Err(FieldTypeUnexpectedStruct {
                         field_name: key.into(),
                         expected_ty: "String".into(),
-                        actual_ty: name,
+                        actual_ty: t.to_string(),
                     }
-                        .into());
+                    .into());
                 }
             };
+            validate_update_path(new_name)?;
         }
-        Ok(RenameOperator {
-            doc
-        })
+        Ok(RenameOperator { doc })
     }
-
-    fn rename_field(doc: &mut Document, key: &str, new_key: &str) -> Result<()> {
-        match doc.remove(key) {
-            Some(value) => {
-                doc.insert(new_key, value);
-            }
-
-            None => {
-                doc.insert(new_key, Bson::Null);
-            }
-        }
-        Ok(())
-    }
-
 }
 
 impl UpdateOperator for RenameOperator {
-
     fn name(&self) -> &str {
         "rename"
     }
@@ -54,18 +38,13 @@ impl UpdateOperator for RenameOperator {
         let doc = value.as_document_mut().unwrap();
 
         let mut updated = false;
-        for (k, v) in self.doc.iter() {
-            let new_name = match v {
-                Bson::String(new_name) => new_name.as_str(),
-                _ => unreachable!()
+        for (source, destination) in self.doc.iter() {
+            let Bson::String(destination) = destination else {
+                unreachable!()
             };
-            RenameOperator::rename_field(doc, k, new_name)?;
-            updated = true;
+            updated |= rename_path(doc, source, destination)?;
         }
 
-        Ok(UpdateResult {
-            updated,
-        })
+        Ok(UpdateResult { updated })
     }
-
 }

--- a/src/polodb_core/vm/update_operators/set_operator.rs
+++ b/src/polodb_core/vm/update_operators/set_operator.rs
@@ -1,4 +1,5 @@
 use bson::{Bson, Document};
+use crate::vm::update_operators::document_path::set_path;
 use crate::vm::update_operators::{UpdateOperator, UpdateResult};
 use crate::Result;
 
@@ -28,8 +29,7 @@ impl UpdateOperator for SetOperator {
 
         let mut updated = false;
         for (k, v) in self.doc.iter() {
-            doc.insert(k.clone(), v.clone());
-            updated = true;
+            updated |= set_path(doc, k, v.clone())?.as_ref() != Some(v);
         }
 
         Ok(UpdateResult {

--- a/src/polodb_core/vm/update_operators/unset_operator.rs
+++ b/src/polodb_core/vm/update_operators/unset_operator.rs
@@ -1,5 +1,6 @@
 use bson::{Bson, Document};
 use crate::Result;
+use crate::vm::update_operators::document_path::remove_path;
 use crate::vm::update_operators::{UpdateOperator, UpdateResult};
 
 pub(crate) struct UnsetOperator {
@@ -9,6 +10,7 @@ pub(crate) struct UnsetOperator {
 impl UnsetOperator {
 
     pub fn compile(doc: &Document) -> Result<UnsetOperator> {
+        <dyn UpdateOperator>::validate_key(doc)?;
         let fields = doc.keys().map(|k| k.to_string()).collect();
         Ok(UnsetOperator {
             fields
@@ -27,8 +29,7 @@ impl UpdateOperator for UnsetOperator {
 
         let mut updated = false;
         for field in &self.fields {
-            doc.remove(field);
-            updated = true;
+            updated |= remove_path(doc, field)?.is_some();
         }
 
         Ok(UpdateResult {


### PR DESCRIPTION
## Summary

- add shared helpers for reading, creating, setting, removing, and renaming nested document paths
- support dotted paths across `$set`, `$unset`, `$inc`, `$mul`, `$min`, `$max`, `$push`, `$pop`, and `$rename`
- create missing intermediate documents when required
- reject `_id` descendants, empty path segments, conflicting paths, and traversal through non-document values
- preserve transaction rollback when a nested update fails

## Compatibility boundary

This PR handles embedded documents only. Positional array paths (`$`, `$[]`, `$[identifier]`) and traversal through arrays remain out of scope.

## Tests

- nested `$set`, `$unset`, `$inc`, and `$push`
- missing intermediate document creation
- non-document intermediate error with rollback
- `_id` descendant and parent/child path conflict rejection
- dotted `$mul`, `$min`, `$max`, `$pop`, and `$rename`
- `git diff --check`
- `cargo metadata --no-deps`

Full cross-platform tests are delegated to GitHub Actions because the bundled RocksDB debug build exceeds the local runner timeout.